### PR TITLE
screen-common.less: Use 'word-break: keep-all'

### DIFF
--- a/resources/print.css
+++ b/resources/print.css
@@ -1,5 +1,11 @@
 /* Styles for print view and printing */
 
+body {
+  /* Word breaks shouldn't be used for CJK text */
+  word-break: keep-all;
+  overflow-wrap: break-word;
+}
+
 .nav-bar,
 #fw-menu,
 #p-navigation-and-watch,

--- a/resources/screen-common.less
+++ b/resources/screen-common.less
@@ -18,6 +18,10 @@ body {
   padding: 0;
   color: #252525;
   line-height: 1.7;
+
+  /* Word breaks shouldn't be used for CJK text */
+  word-break: keep-all;
+  overflow-wrap: break-word;
 }
 
 :focus {


### PR DESCRIPTION
Word breaks should not be used for Korean text.

##### References
- https://developer.mozilla.org/en-US/docs/Web/CSS/word-break
- https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-wrap