### PR TITLE
Define font-family for `[lang=ja]`

### DIFF
--- a/resources/skins.femiwiki/elements.less
+++ b/resources/skins.femiwiki/elements.less
@@ -15,7 +15,7 @@ html {
   font-family: @font-family;
 }
 
-[lang=ja] {
+[lang='ja'] {
   font-family: @font-family-ja;
 }
 

--- a/resources/skins.femiwiki/elements.less
+++ b/resources/skins.femiwiki/elements.less
@@ -15,6 +15,10 @@ html {
   font-family: @font-family;
 }
 
+[lang=ja] {
+  font-family: @font-family-ja;
+}
+
 body {
   padding: 0;
   color: @color-base15;

--- a/resources/variables.less
+++ b/resources/variables.less
@@ -12,6 +12,8 @@
   'Noto Sans CJK KR', 'KoPubDotum Medium', '나눔바른고딕', '나눔고딕',
   NanumGothic, '맑은고딕', 'Malgun Gothic', Arial, Dotum, sans-serif;
 
+@font-family-ja: "Segoe UI", Meiryo, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+
 @color-base0: #000000;
 @color-base15: #252525;
 @color-base100: #fff;

--- a/resources/variables.less
+++ b/resources/variables.less
@@ -12,7 +12,8 @@
   'Noto Sans CJK KR', 'KoPubDotum Medium', '나눔바른고딕', '나눔고딕',
   NanumGothic, '맑은고딕', 'Malgun Gothic', Arial, Dotum, sans-serif;
 
-@font-family-ja: "Segoe UI", Meiryo, system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+@font-family-ja: 'Segoe UI', Meiryo, system-ui, -apple-system,
+  BlinkMacSystemFont, sans-serif;
 
 @color-base0: #000000;
 @color-base15: #252525;


### PR DESCRIPTION
Currently the stylesheet applies Korean fonts to every text, which is particularly bad for Japanese text on Windows (since Malgun Gothic supports Kana). This makes sure texts marked as `[lang=ja]` get a proper Japanese font.

Closes #228