### PR TITLE
Minor bug fixes

### DIFF
--- a/resources/skins.femiwiki.moduleSkinStyles/ext.uls.preferencespage.less
+++ b/resources/skins.femiwiki.moduleSkinStyles/ext.uls.preferencespage.less
@@ -1,0 +1,5 @@
+@import '../variables.less';
+
+.uls-preferences-link-wrapper a {
+  .mw-link-style();
+}

--- a/resources/skins.femiwiki.moduleSkinStyles/ext.visualEditor.mwimage.less
+++ b/resources/skins.femiwiki.moduleSkinStyles/ext.visualEditor.mwimage.less
@@ -1,0 +1,5 @@
+@import '../variables.less';
+
+.ve-ui-mwMediaDialog-description-link {
+  .mw-link-style();
+}

--- a/resources/skins.femiwiki.moduleSkinStyles/mediawiki.action.view.postEdit.less
+++ b/resources/skins.femiwiki.moduleSkinStyles/mediawiki.action.view.postEdit.less
@@ -1,0 +1,6 @@
+// https://github.com/femiwiki/FemiwikiSkin/issues/45
+// TODO: Remove this in MediaWiki 1.37
+.postedit.mw-notification {
+  -webkit-transform: none;
+  transform: none;
+}

--- a/resources/variables.less
+++ b/resources/variables.less
@@ -78,6 +78,88 @@
   vertical-align: middle;
 }
 
+.mw-link-style() {
+  &,
+  &:visited {
+    color: @color-primary5;
+  }
+
+  &:active {
+    color: #faa700;
+  }
+
+  &:hover,
+  &:focus {
+    text-decoration: underline;
+  }
+
+  &.external {
+    color: @color-primary5;
+  }
+
+  &.new {
+    color: #c0081f;
+
+    &:visited {
+      color: #a55858;
+    }
+  }
+
+  &.stub {
+    color: #723;
+  }
+
+  // self links
+  &.mw-selflink {
+    color: inherit;
+    font-weight: bold;
+    text-decoration: inherit;
+
+    &:hover {
+      cursor: inherit;
+      text-decoration: inherit;
+    }
+
+    &:active,
+    &:visited {
+      color: inherit;
+    }
+  }
+
+  // Interwiki Styling
+  &.extiw {
+    &,
+    &:active {
+      color: #36b;
+    }
+
+    &:visited {
+      color: #636;
+    }
+
+    &:active {
+      color: #b63;
+    }
+  }
+
+  // External links
+  &.external {
+    color: @color-primary5;
+    /* @embed */
+    background: url('../images/icon-external-link.png') top right no-repeat;
+    background-size: 8px 8px;
+    padding-right: 0.6rem;
+
+    &:active {
+      color: #b63;
+    }
+
+    &.free {
+      word-wrap: break-word;
+    }
+  }
+}
+
 .mw-link() {
   &:not([role='button']) {
     text-decoration: none;
@@ -86,85 +168,7 @@
       cursor: pointer; // Always cursor:pointer even without href
     }
 
-    &,
-    &:visited {
-      color: @color-primary5;
-    }
-
-    &:active {
-      color: #faa700;
-    }
-
-    &:hover,
-    &:focus {
-      text-decoration: underline;
-    }
-
-    &.external {
-      color: @color-primary5;
-    }
-
-    &.new {
-      color: #c0081f;
-
-      &:visited {
-        color: #a55858;
-      }
-    }
-
-    &.stub {
-      color: #723;
-    }
-
-    // self links
-    &.mw-selflink {
-      color: inherit;
-      font-weight: bold;
-      text-decoration: inherit;
-
-      &:hover {
-        cursor: inherit;
-        text-decoration: inherit;
-      }
-
-      &:active,
-      &:visited {
-        color: inherit;
-      }
-    }
-
-    // Interwiki Styling
-    &.extiw {
-      &,
-      &:active {
-        color: #36b;
-      }
-
-      &:visited {
-        color: #636;
-      }
-
-      &:active {
-        color: #b63;
-      }
-    }
-
-    // External links
-    &.external {
-      color: @color-primary5;
-      /* @embed */
-      background: url('../images/icon-external-link.png') top right no-repeat;
-      background-size: 8px 8px;
-      padding-right: 0.6rem;
-
-      &:active {
-        color: #b63;
-      }
-
-      &.free {
-        word-wrap: break-word;
-      }
-    }
+    .mw-link-style();
   }
 }
 

--- a/resources/variables.less
+++ b/resources/variables.less
@@ -492,7 +492,6 @@
     border: none;
     background-color: #f0f0f0;
     color: @color-base0;
-    padding: 1em;
     white-space: pre-wrap;
   }
 

--- a/skin.json
+++ b/skin.json
@@ -148,6 +148,7 @@
       "+ext.templateDataGenerator.editPage": "skins.femiwiki.moduleSkinStyles/ext.templateDataGenerator.editPage.less",
       "+ext.translate": "skins.femiwiki.moduleSkinStyles/ext.translate.less",
       "+ext.TwoColConflict.SplitCss": "skins.femiwiki.moduleSkinStyles/ext.TwoColConflict.SplitCss.less",
+      "+ext.uls.preferencespage": "skins.femiwiki.moduleSkinStyles/ext.uls.preferencespage.less",
       "+ext.uploadWizard.page.styles": "skins.femiwiki.moduleSkinStyles/ext.uploadWizard.page.styles.less",
       "+ext.visualEditor.core": "skins.femiwiki.moduleSkinStyles/ext.visualEditor.core.less",
       "+ext.visualEditor.desktopTarget": "skins.femiwiki.moduleSkinStyles/ext.visualEditor.desktopTarget.less",

--- a/skin.json
+++ b/skin.json
@@ -155,6 +155,7 @@
       "+mediawiki.action.history.styles": "skins.femiwiki.moduleSkinStyles/mediawiki.action.history.styles.less",
       "+mediawiki.action.view.categoryPage.styles": "skins.femiwiki.moduleSkinStyles/mediawiki.action.view.categoryPage.styles.less",
       "+mediawiki.action.view.filepage": "skins.femiwiki.moduleSkinStyles/mediawiki.action.view.filepage.less",
+      "+mediawiki.action.view.postEdit": "skins.femiwiki.moduleSkinStyles/mediawiki.action.view.postEdit.less",
       "+mediawiki.diff.styles": "skins.femiwiki.moduleSkinStyles/mediawiki.diff.styles.less",
       "+mediawiki.feedlink": "skins.femiwiki.moduleSkinStyles/mediawiki.feedlink.less",
       "+mediawiki.pulsatingdot": "skins.femiwiki.moduleSkinStyles/mediawiki.pulsatingdot.less",

--- a/skin.json
+++ b/skin.json
@@ -152,6 +152,7 @@
       "+ext.uploadWizard.page.styles": "skins.femiwiki.moduleSkinStyles/ext.uploadWizard.page.styles.less",
       "+ext.visualEditor.core": "skins.femiwiki.moduleSkinStyles/ext.visualEditor.core.less",
       "+ext.visualEditor.desktopTarget": "skins.femiwiki.moduleSkinStyles/ext.visualEditor.desktopTarget.less",
+      "+ext.visualEditor.mwimage": "skins.femiwiki.moduleSkinStyles/ext.visualEditor.mwimage.less",
       "+mediawiki.action.edit.styles": "skins.femiwiki.moduleSkinStyles/mediawiki.action.edit.styles.less",
       "+mediawiki.action.history.styles": "skins.femiwiki.moduleSkinStyles/mediawiki.action.history.styles.less",
       "+mediawiki.action.view.categoryPage.styles": "skins.femiwiki.moduleSkinStyles/mediawiki.action.view.categoryPage.styles.less",


### PR DESCRIPTION
- Removes padding of `.mwhighlight > pre`. (Closes https://github.com/femiwiki/FemiwikiSkin/issues/245)
- Makes postEdit notification centered evenly. (Closes https://github.com/femiwiki/FemiwikiSkin/issues/45)
- Fixes blue link for ULS in Special:Preferences. (Closes https://github.com/femiwiki/FemiwikiSkin/issues/244)
- Fixes blue link to description page in media settings. (Closes https://github.com/femiwiki/FemiwikiSkin/issues/247)