### PR TITLE
Improve the header of the article

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,3 +8,5 @@
 # auto-genereted files
 /resources/ooui/
 /resources/skins.femiwiki.moduleSkinStyles/ext.pygments.css
+
+*.svg

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -119,7 +119,7 @@ class Hooks {
 	 * @return void
 	 */
 	private static function addNotification( &$personalTools, &$title, $sk ) {
-		if ( !ExtensionRegistry::getInstance()->isLoaded( 'Echo' ) ) {
+		if ( !$sk instanceof SkinFemiwiki || !ExtensionRegistry::getInstance()->isLoaded( 'Echo' ) ) {
 			return;
 		}
 
@@ -188,7 +188,7 @@ class Hooks {
 	 * @param SkinTemplate $sk
 	 */
 	private static function addMobileOptions( &$personalTools, &$title, $sk ) {
-		if ( !ExtensionRegistry::getInstance()->isLoaded( 'MobileFrontend' ) ) {
+		if ( !$sk instanceof SkinFemiwiki || !ExtensionRegistry::getInstance()->isLoaded( 'MobileFrontend' ) ) {
 			return;
 		}
 
@@ -241,6 +241,19 @@ class Hooks {
 			$sk->getSkinName() === Constants::SKIN_NAME &&
 			$title && $title->canExist()
 		) {
+			// Show the watch action anonymous users
+			if ( !$sk->loggedin ) {
+				$content_navigation['actions']['watch'] = [
+					'class' => 'mw-watchlink-watch',
+					'text' => $sk->msg( 'watch' )->text(),
+					'href' => $title->getLocalURL( [ 'action' => 'watch' ] ),
+					'data' => [
+						'mw' => 'interface',
+					],
+				];
+			}
+
+			// Promote watch link from actions to views
 			$key = null;
 			if ( isset( $content_navigation['actions']['watch'] ) ) {
 				$key = 'watch';
@@ -249,7 +262,6 @@ class Hooks {
 				$key = 'unwatch';
 			}
 
-			// Promote watch link from actions to views and add an icon
 			if ( $key !== null ) {
 				$content_navigation['namespaces'][$key] = $content_navigation['actions'][$key];
 				unset( $content_navigation['actions'][$key] );

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -255,18 +255,20 @@ class Hooks {
 			}
 
 			// Promote watch link from actions to views
-			$key = null;
 			if ( isset( $content_navigation['actions']['watch'] ) ) {
 				$key = 'watch';
-			}
-			if ( isset( $content_navigation['actions']['unwatch'] ) ) {
+			} elseif ( isset( $content_navigation['actions']['unwatch'] ) ) {
 				$key = 'unwatch';
+			} else {
+				return;
 			}
 
-			if ( $key !== null ) {
-				$content_navigation['namespaces'][$key] = $content_navigation['actions'][$key];
-				unset( $content_navigation['actions'][$key] );
+			$item = $content_navigation['actions'][$key];
+			if ( !$item ) {
+				return;
 			}
+			$content_navigation['namespaces'][$key] = $item;
+			unset( $content_navigation['actions'][$key] );
 		}
 	}
 }

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -236,11 +236,12 @@ class Hooks {
 	 * @param array &$content_navigation
 	 */
 	public static function onSkinTemplateNavigation( $sk, &$content_navigation ) {
+		if ( $sk->getSkinName() !== Constants::SKIN_NAME ) {
+			return;
+		}
+
 		$title = $sk->getRelevantTitle();
-		if (
-			$sk->getSkinName() === Constants::SKIN_NAME &&
-			$title && $title->canExist()
-		) {
+		if ( $title && $title->canExist() ) {
 			// Show the watch action anonymous users
 			if ( !$sk->loggedin ) {
 				$content_navigation['actions']['watch'] = [

--- a/includes/templates/Header.mustache
+++ b/includes/templates/Header.mustache
@@ -1,9 +1,6 @@
 <header id="p-header" class="fw-header">
   <div id="siteNotice" class="mw-body-content">{{{html-site-notice}}}</div>
   {{{html-user-message}}}
-  {{#data-portlets.data-namespaces}}
-    {{>Menu}}
-  {{/data-portlets.data-namespaces}}
   <div id="p-title-and-tb">
     <h1 id="firstHeading" class="firstHeading" {{{html-heading-language-attributes}}}>{{{html-title}}}</h1>
     <div id="p-title-buttons">
@@ -31,4 +28,7 @@
     {{>Menu}}
     {{/data-portlets.data-views}}
   </div>
+  {{#data-portlets.data-namespaces}}
+    {{>Menu}}
+  {{/data-portlets.data-namespaces}}
 </header>

--- a/includes/templates/Header.mustache
+++ b/includes/templates/Header.mustache
@@ -1,9 +1,10 @@
 <header id="p-header" class="fw-header">
   <div id="siteNotice" class="mw-body-content">{{{html-site-notice}}}</div>
   {{{html-user-message}}}
-  <div id="p-title-and-tb">
-    <h1 id="firstHeading" class="firstHeading" {{{html-heading-language-attributes}}}>{{{html-title}}}</h1>
-    <div id="p-title-buttons">
+  <h1 id="firstHeading" class="firstHeading" {{{html-heading-language-attributes}}}>{{{html-title}}}</h1>
+  <div id="p-title-buttons">
+    {{#data-portlets.data-namespaces}}{{>Menu}}{{/data-portlets.data-namespaces}}
+    <div class="right-buttons">
       {{{html-share-button}}}
       {{>Indicator}}
       <label id="p-menu-toggle"
@@ -13,22 +14,16 @@
         aria-controls="p-actions-and-toolbox"
         tabindex="0"></label>
     </div>
-    <input type="checkbox" id="fw-page-menu-checkbox" class="mw-checkbox-hack-checkbox">
-    <div id="p-actions-and-toolbox" class="fw-portals fw-page-portals">
-      {{#data-toolbox}}{{>Menu}}{{/data-toolbox}}
-      {{#data-portlets.data-actions}}{{>Menu}}{{/data-portlets.data-actions}}
-    </div>
+  </div>
+  <input type="checkbox" id="fw-page-menu-checkbox" class="mw-checkbox-hack-checkbox">
+  <div id="p-actions-and-toolbox" class="fw-portals fw-page-portals">
+    {{#data-toolbox}}{{>Menu}}{{/data-toolbox}}
+    {{#data-portlets.data-actions}}{{>Menu}}{{/data-portlets.data-actions}}
   </div>
   <div id="lastmod-and-views">
     {{#link-history}}
     <a id="lastmod" href="{{link-history}}">{{{html-lastmod}}}</a>
     {{/link-history}}
-
-    {{#data-portlets.data-views}}
-    {{>Menu}}
-    {{/data-portlets.data-views}}
+    {{#data-portlets.data-views}}{{>Menu}}{{/data-portlets.data-views}}
   </div>
-  {{#data-portlets.data-namespaces}}
-    {{>Menu}}
-  {{/data-portlets.data-namespaces}}
 </header>

--- a/resources/@types/mediawiki.d.ts
+++ b/resources/@types/mediawiki.d.ts
@@ -1,3 +1,20 @@
+interface MwApi {
+  saveOption(name: string, value: unknown): JQuery.Promise<any>;
+
+  get(parameters: object, ajaxOptions?: object): JQuery.Promise<any>;
+}
+
+type MwApiConstructor = new (options?: Object) => MwApi;
+
+interface MwTitle {
+  getNamespacePrefix(): string;
+  getMain(): string;
+  getTalkPage(): MwTitle | null;
+  getPrefixedText(): string;
+}
+
+type MwTitleConstructor = new (title: string, namespace?: string) => MwTitle;
+
 interface MediaWiki {
   now(): number;
 
@@ -38,6 +55,10 @@ interface MediaWiki {
   };
 
   Message: {};
+
+  Api: MwApiConstructor;
+
+  Title: MwTitleConstructor;
 
   Uri: {
     new (uri?: Object | string, options?: Object | boolean): MediaWiki['Uri'];

--- a/resources/skins.femiwiki.js/discussionStatus.js
+++ b/resources/skins.femiwiki.js/discussionStatus.js
@@ -1,0 +1,40 @@
+function init() {
+  var title = new mw.Title(mw.config.get('wgPageName'));
+  var talkPage = title.getTalkPage();
+  if (!talkPage) {
+    return;
+  }
+  var talkName = talkPage.getPrefixedText();
+  var api = new mw.Api();
+
+  api
+    .get({
+      action: 'flow',
+      page: talkName,
+      limit: 10,
+      submodule: 'view-topiclist',
+    })
+    .done(function (data) {
+      var topiclist = data.flow['view-topiclist']['result']['topiclist'];
+      var revisions = topiclist['revisions'];
+
+      var locked = 0;
+      for (var key in revisions) {
+        if (revisions[key]['changeType'] == 'lock-topic') locked++;
+      }
+
+      var roots = topiclist['roots'];
+      var num = roots.length;
+      var $anchor = $('#ca-talk a');
+      $anchor.text(num > 9 ? '9+' : num);
+
+      var $talk = $('#ca-talk');
+      $talk.addClass('label');
+      var open = num - locked;
+      if (open) {
+        $talk.addClass('has-open-topic');
+      }
+    });
+}
+
+module.exports = Object.freeze({ init: init });

--- a/resources/skins.femiwiki.js/skin.js
+++ b/resources/skins.femiwiki.js/skin.js
@@ -23,8 +23,10 @@ function initCheckboxHack(checkbox, button) {
  * @return {void}
  */
 function main() {
-  require('./searchClearButton.js').init();
+  require('./discussionStatus.js').init();
   require('./notificationBadge.js').init();
+  require('./searchClearButton.js').init();
+  require('./watchingUsers.js').init();
 
   initCheckboxHack(
     window.document.getElementById('fw-menu-checkbox'),

--- a/resources/skins.femiwiki.js/watchingUsers.js
+++ b/resources/skins.femiwiki.js/watchingUsers.js
@@ -4,9 +4,6 @@ function init() {
     return;
   }
   var $watchAnchor = $watchLink.children('a');
-  if (mw.config.get('wgArticleId') === 0) {
-    return;
-  }
   var watchers = 0;
   $watchLink.on('watchpage.mw', function (_, otherAction) {
     if (otherAction == 'watch') {

--- a/resources/skins.femiwiki.js/watchingUsers.js
+++ b/resources/skins.femiwiki.js/watchingUsers.js
@@ -32,19 +32,17 @@ function init() {
       inprop: 'watchers',
     })
     .done(function (data) {
-      var pages = data.query.pages;
-      var newWatchers;
-      for (var p in data.query.pages) {
-        newWatchers = pages[p].watchers;
-      }
-      if (!$watchLink || !newWatchers || newWatchers === 0) {
+      if (!$watchLink || !$watchAnchor) {
         return;
       }
-      watchers = newWatchers;
 
-      if ($watchAnchor) {
-        $watchAnchor.html(watchers.toString());
+      var newWatchers = Object.values(data.query.pages)[0].watchers;
+      if (!newWatchers || newWatchers === watchers) {
+        return;
       }
+
+      watchers = newWatchers;
+      $watchAnchor.html(watchers.toString());
       $watchLink.addClass('label');
     });
 }

--- a/resources/skins.femiwiki.js/watchingUsers.js
+++ b/resources/skins.femiwiki.js/watchingUsers.js
@@ -1,0 +1,55 @@
+function init() {
+  var $watchLink = $('.mw-watchlink, .mw-watchlink-watch');
+  if (!$watchLink) {
+    return;
+  }
+  var $watchAnchor = $watchLink.children('a');
+  if (mw.config.get('wgArticleId') === 0) {
+    return;
+  }
+  var watchers = 0;
+  $watchLink.on('watchpage.mw', function (_, otherAction) {
+    if (otherAction == 'watch') {
+      watchers++;
+    } else {
+      watchers--;
+    }
+  });
+
+  $watchLink.on('DOMSubtreeModified', function (event) {
+    switch (event.target.innerHTML) {
+      case mw.msg('watching'):
+      case mw.msg('watch'):
+        $watchLink.addClass('label');
+      case mw.msg('unwatching'):
+      case mw.msg('unwatch'):
+        $watchAnchor.html(watchers.toString());
+    }
+  });
+  new mw.Api()
+    .get({
+      action: 'query',
+      format: 'json',
+      titles: mw.config.get('wgPageName'),
+      prop: 'info',
+      inprop: 'watchers',
+    })
+    .done(function (data) {
+      var pages = data.query.pages;
+      var newWatchers;
+      for (var p in data.query.pages) {
+        newWatchers = pages[p].watchers;
+      }
+      if (!$watchLink || !newWatchers || newWatchers === 0) {
+        return;
+      }
+      watchers = newWatchers;
+
+      if ($watchAnchor) {
+        $watchAnchor.html(watchers.toString());
+      }
+      $watchLink.addClass('label');
+    });
+}
+
+module.exports = Object.freeze({ init: init });

--- a/resources/skins.femiwiki/images/speechBubbles-ltr-new.svg
+++ b/resources/skins.femiwiki/images/speechBubbles-ltr-new.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+	<title>
+		speech bubbles
+	</title><g fill="#a5c831">
+	<path d="M17 4v7a2 2 0 01-2 2H4v1a2 2 0 002 2h10l4 4V6a2 2 0 00-2-2zM6 10H0v6z"/>
+	<rect width="16" height="12" rx="2"/>
+</g></svg>

--- a/resources/skins.femiwiki/images/speechBubbles-rtl-new.svg
+++ b/resources/skins.femiwiki/images/speechBubbles-rtl-new.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
+	<title>
+		speech bubbles
+	</title><g fill="#a5c831">
+	<path d="M0 20l4-4h10c1.1 0 2-.9 2-2v-1H5c-1.1 0-2-.9-2-2V4H2C.9 4 0 4.9 0 6zm14-10h6v6z"/>
+	<rect width="16" height="12" x="4" rx="2"/>
+</g></svg>

--- a/resources/skins.femiwiki/interface.less
+++ b/resources/skins.femiwiki/interface.less
@@ -109,10 +109,6 @@
   }
 
   .mw-portlet-namespaces {
-    margin: 0 -@padding-icon 0.5rem;
-    overflow: hidden;
-    clear: both;
-
     h3 {
       display: none;
     }
@@ -216,101 +212,103 @@
           background-image: /* @embed */ url(../ooui/images/icons/star.svg);
         }
         &#ca-unwatch a:before {
-          background-image: /* @embed */ url(../ooui/images/icons/unStar.svg);
+          background-image: /* @embed */ url(../ooui/images/icons/unStar-progressive.svg);
+          opacity: unset;
         }
       }
     }
   }
 
-  #p-title-and-tb {
-    margin-right: -@padding-icon;
-    clear: both;
+  #fw-page-menu-checkbox:not(:checked) ~ #p-actions-and-toolbox {
+    display: none;
+  }
 
-    #fw-page-menu-checkbox:not(:checked) ~ #p-actions-and-toolbox {
-      display: none;
+  #p-title-buttons {
+    margin: 0 -@padding-icon;
+    clear: both;
+    @icon-size: 1.42857143em;
+    overflow: hidden;
+
+    .right-buttons {
+      float: right;
     }
 
-    #p-title-buttons {
-      float: right;
+    .mw-indicator,
+    #p-menu-toggle {
+      &:hover,
+      &:focus {
+        background-color: @button-hover-background-color;
+      }
+    }
+
+    .mw-indicators,
+    .fw-button {
       margin: 0;
-      @icon-size: 1.42857143em;
+      float: left;
 
-      .mw-indicator,
-      #p-menu-toggle {
-        &:hover,
-        &:focus {
-          background-color: @button-hover-background-color;
-        }
+      &,
+      & a,
+      &:focus,
+      & a:focus {
+        // Remove highlighting
+        border: none;
+        box-shadow: none;
       }
+    }
 
-      .mw-indicators,
-      .fw-button {
-        margin: 0;
-        float: left;
+    #p-share .oo-ui-icon-share {
+      background-image: url(images/icon-share.png);
+      opacity: @opacity-icon;
+    }
 
-        &,
-        & a,
-        &:focus,
-        & a:focus {
-          // Remove highlighting
-          border: none;
-          box-shadow: none;
-        }
-      }
+    #p-menu-toggle,
+    .mw-indicators,
+    .mw-indicator {
+      width: @icon-size;
+      height: @icon-size;
+    }
 
-      #p-share .oo-ui-icon-share {
-        background-image: url(images/icon-share.png);
+    .mw-indicators,
+    #p-menu-toggle {
+      padding: 0.37142855em;
+    }
+
+    // Hide text label
+    // Reference: TabWatchstarLink.less of Vector.
+    .mw-indicators .mw-indicator a {
+      overflow: hidden;
+      height: 0;
+      position: relative;
+      width: @icon-size;
+      padding-top: @icon-size;
+      // Reset
+      background: none;
+      padding-left: 0;
+
+      &:before {
+        background-image: /* @embed */ url(../../../../resources/src/mediawiki.helplink/images/helpNotice.svg);
+        background-position: center;
+        background-repeat: no-repeat;
         opacity: @opacity-icon;
-      }
-
-      #p-menu-toggle,
-      .mw-indicators,
-      .mw-indicator {
+        content: '';
+        display: block;
+        position: absolute;
+        top: 0;
+        left: 0;
         width: @icon-size;
         height: @icon-size;
       }
+    }
 
-      .mw-indicators,
-      #p-menu-toggle {
-        padding: 0.37142855em;
-      }
-
-      // Hide text label
-      // Reference: TabWatchstarLink.less of Vector.
-      .mw-indicators .mw-indicator a {
-        overflow: hidden;
-        height: 0;
-        position: relative;
-        width: @icon-size;
-        padding-top: @icon-size;
-        // Reset
-        background: none;
-        padding-left: 0;
-
-        &:before {
-          background-image: /* @embed */ url(../../../../resources/src/mediawiki.helplink/images/helpNotice.svg);
-          background-position: center;
-          background-repeat: no-repeat;
-          opacity: @opacity-icon;
-          content: '';
-          display: block;
-          position: absolute;
-          top: 0;
-          left: 0;
-          width: @icon-size;
-          height: @icon-size;
-        }
-      }
-
-      #p-menu-toggle {
-        background-size: @icon-size;
-        background-position: center center;
-        background-repeat: no-repeat;
-        opacity: @opacity-icon;
-        cursor: pointer;
-      }
+    #p-menu-toggle {
+      background-size: @icon-size;
+      background-position: center center;
+      background-repeat: no-repeat;
+      opacity: @opacity-icon;
+      cursor: pointer;
     }
   }
+
   #lastmod-and-views {
     font-size: 0.75rem;
     overflow: hidden;
@@ -359,8 +357,8 @@
   }
 }
 
-// firstHeading and its preivew output of VisualEditor
-#p-header #p-title-and-tb h1.firstHeading,
+// firstHeading and its preview output of VisualEditor
+#p-header h1.firstHeading,
 .oo-ui-window .mw-body-content h1.firstHeading {
   font-size: 1.714rem;
   display: inline-block;

--- a/resources/skins.femiwiki/interface.less
+++ b/resources/skins.femiwiki/interface.less
@@ -122,7 +122,7 @@
         @size-icon: 1.42857143rem;
         @width: @size-icon + @padding-icon * 2;
         @height: @size-icon + @padding-icon * 2;
-        float: right;
+        float: left;
 
         a {
           color: @color-base15;
@@ -131,11 +131,6 @@
           &:focus {
             text-decoration: none;
           }
-        }
-
-        &#ca-watch,
-        &#ca-unwatch {
-          float: left;
         }
 
         &.selected {

--- a/resources/skins.femiwiki/interface.less
+++ b/resources/skins.femiwiki/interface.less
@@ -46,6 +46,7 @@
         }
 
         i::before {
+          opacity: @opacity-icon;
           vertical-align: middle;
           margin-right: 0.3em;
           font-size: 1.5em;
@@ -108,8 +109,9 @@
   }
 
   .mw-portlet-namespaces {
-    font-size: 0.75rem;
-    margin-bottom: 0.5rem;
+    margin: 0 -@padding-icon 0.5rem;
+    overflow: hidden;
+    clear: both;
 
     h3 {
       display: none;
@@ -117,24 +119,116 @@
 
     ul {
       li {
-        display: inline-block;
+        @size-icon: 1.42857143rem;
+        @width: @size-icon + @padding-icon * 2;
+        @height: @size-icon + @padding-icon * 2;
+        float: right;
+
+        a {
+          color: @color-base15;
+
+          &:hover,
+          &:focus {
+            text-decoration: none;
+          }
+        }
+
+        &#ca-watch,
+        &#ca-unwatch {
+          float: left;
+        }
 
         &.selected {
           display: none;
         }
 
-        &:not(:last-child) {
-          margin-right: 0.5rem;
+        // Only use icon
+        // Reference: TabWatchstarLink.less of Vector.
+        & {
+          display: block;
+          width: @width;
+          height: @height;
+
+          a {
+            display: block;
+            width: @width;
+            height: 0;
+            padding: @height 0 0 0;
+            overflow: hidden;
+            position: relative;
+
+            &:before {
+              background-repeat: no-repeat;
+              background-position: 50% 50%;
+              opacity: @opacity-icon;
+              content: '';
+              display: block;
+              position: absolute;
+              top: @padding-icon;
+              left: @padding-icon;
+              width: @size-icon;
+              height: @size-icon;
+            }
+
+            &:hover {
+              background-color: @button-hover-background-color;
+            }
+          }
+
+          &.selected {
+            display: none;
+          }
+
+          &.label {
+            width: auto;
+            a {
+              width: auto;
+              height: auto;
+              padding: @padding-icon;
+              line-height: @size-icon;
+
+              &:before {
+                position: relative;
+                margin-right: @padding-icon;
+                top: 0;
+                left: 0;
+                float: left;
+              }
+            }
+          }
         }
 
-        a {
-          .mw-link();
+        &[id^='ca-nstab-'] a:before {
+          background-image: /* @embed */ url(../ooui/images/icons/article-ltr.svg);
+          .rtl & {
+            background-image: /* @embed */ url(../ooui/images/icons/article-rtl.svg);
+          }
+        }
+        &#ca-talk a:before {
+          background-image: /* @embed */ url(../ooui/images/icons/speechBubbles-ltr.svg);
+          .rtl & {
+            background-image: /* @embed */ url(../ooui/images/icons/speechBubbles-rtl.svg);
+          }
+        }
+        &#ca-talk.has-open-topic a:before {
+          opacity: unset;
+          background-image: /* @embed */ url(images/speechBubbles-ltr-new.svg);
+          .rtl & {
+            background-image: /* @embed */ url(images/speechBubbles-ltr-new.svg);
+          }
+        }
+        &#ca-watch a:before {
+          background-image: /* @embed */ url(../ooui/images/icons/star.svg);
+        }
+        &#ca-unwatch a:before {
+          background-image: /* @embed */ url(../ooui/images/icons/unStar.svg);
         }
       }
     }
   }
 
   #p-title-and-tb {
+    margin-right: -@padding-icon;
     clear: both;
 
     #fw-page-menu-checkbox:not(:checked) ~ #p-actions-and-toolbox {
@@ -146,15 +240,18 @@
       margin: 0;
       @icon-size: 1.42857143em;
 
-      .mw-indicators,
-      .fw-button {
-        margin: 0;
-        float: left;
-
+      .mw-indicator,
+      #p-menu-toggle {
         &:hover,
         &:focus {
           background-color: @button-hover-background-color;
         }
+      }
+
+      .mw-indicators,
+      .fw-button {
+        margin: 0;
+        float: left;
 
         &,
         & a,
@@ -168,6 +265,7 @@
 
       #p-share .oo-ui-icon-share {
         background-image: url(images/icon-share.png);
+        opacity: @opacity-icon;
       }
 
       #p-menu-toggle,
@@ -195,9 +293,10 @@
         padding-left: 0;
 
         &:before {
-          background-image: url(../../../../resources/src/mediawiki.helplink/images/helpNotice.svg);
+          background-image: /* @embed */ url(../../../../resources/src/mediawiki.helplink/images/helpNotice.svg);
           background-position: center;
           background-repeat: no-repeat;
+          opacity: @opacity-icon;
           content: '';
           display: block;
           position: absolute;
@@ -212,6 +311,7 @@
         background-size: @icon-size;
         background-position: center center;
         background-repeat: no-repeat;
+        opacity: @opacity-icon;
         cursor: pointer;
       }
     }

--- a/resources/variables.less
+++ b/resources/variables.less
@@ -50,6 +50,8 @@
 @color-alert-border: @color-secondary2;
 
 @button-hover-background-color: rgba(0, 24, 73, 0.02745098);
+@opacity-icon: 65%;
+@padding-icon: 0.37142855rem;
 
 @keyframes gentle-pulse {
   0% {

--- a/skin.json
+++ b/skin.json
@@ -85,8 +85,10 @@
       "targets": ["desktop", "mobile"],
       "packageFiles": [
         "skins.femiwiki.js/skin.js",
+        "skins.femiwiki.js/discussionStatus.js",
         "skins.femiwiki.js/notificationBadge.js",
-        "skins.femiwiki.js/searchClearButton.js"
+        "skins.femiwiki.js/searchClearButton.js",
+        "skins.femiwiki.js/watchingUsers.js"
       ],
       "dependencies": ["oojs", "oojs-ui-core", "mediawiki.page.ready"]
     },


### PR DESCRIPTION
- Uses icons for namespaces and watch/unwatch navigations.
- Moves navigations below the first heading.
- Makes black icons less dark as they are not important than headings.
- Shows numbers follow the discussion and watch.
- Shows the watch action to anonymous users to encourage signing-ups.

| Previous | This patch makes |
|--|--|
| ![image](https://user-images.githubusercontent.com/28209361/124206206-dc361b00-db1d-11eb-8a3e-c45b97de4a2e.png) | ![image](https://user-images.githubusercontent.com/28209361/124206178-c9bbe180-db1d-11eb-87bb-fb713f532a96.png) |