### PR TITLE
Replace underline of links with border-bottom

### DIFF
--- a/resources/skins.femiwiki.moduleSkinStyles/ext.relatedArticles.cards.less
+++ b/resources/skins.femiwiki.moduleSkinStyles/ext.relatedArticles.cards.less
@@ -1,5 +1,9 @@
 @media all and (min-width: 720px) {
   .ext-related-articles-card-list {
+    h3 a {
+      text-decoration: none;
+    }
+
     // Make 2-columns
     .ext-related-articles-card {
       @rightMargin: 1%;

--- a/resources/variables.less
+++ b/resources/variables.less
@@ -115,7 +115,7 @@
 
   &:hover,
   &:focus {
-    text-decoration: underline;
+    border-bottom: 1px solid;
   }
 
   &.external {

--- a/resources/variables.less
+++ b/resources/variables.less
@@ -185,7 +185,8 @@
 }
 
 .mw-link() {
-  &:not([role='button']) {
+  // menuitem is for the dropdown menu of the WikiEditor.
+  &:not([role='button']):not([role='menuitem']) {
     text-decoration: none;
 
     &:not([href]) {


### PR DESCRIPTION
Replaces underline of links with `border-bottom` which is more customizable.

Closes #15.