### PR TITLE
Template directory should be relative to skin

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -8,7 +8,7 @@
   "license-name": "AGPL-3.0-or-later",
   "type": "skin",
   "requires": {
-    "MediaWiki": ">= 1.36.0"
+    "MediaWiki": ">= 1.37.0"
   },
   "ValidSkinNames": {
     "femiwiki": {
@@ -18,7 +18,7 @@
         {
           "name": "femiwiki",
           "responsive": true,
-          "templateDirectory": "skins/Femiwiki/includes/templates",
+          "templateDirectory": "includes/templates",
           "styles": [
             "skins.femiwiki",
             "skins.femiwiki.xeicon",


### PR DESCRIPTION
In 1.37 support was added for declaring template directory relative
to skin. Relative to core is deprecated in 1.37, will likely be removed
in 1.39