### PR TITLE
Make the label for category use single line

### DIFF
--- a/resources/skins.femiwiki/contents.less
+++ b/resources/skins.femiwiki/contents.less
@@ -92,8 +92,7 @@
     clear: both;
 
     ul {
-      display: inline;
-      margin: 0;
+      margin-top: 0;
       padding: 0;
       // @See https://github.com/femiwiki/FemiwikiSkin/issues/152
       word-break: break-all;


### PR DESCRIPTION
## Previous

![image](https://user-images.githubusercontent.com/28209361/145177479-84e3ab2e-350e-4d49-bad1-8d3e01e97de3.png)

## This patch changes to
![image](https://user-images.githubusercontent.com/28209361/145177399-b327cef6-217b-42fe-80fe-b754bb5c72f3.png)

Closes #371