### PR TITLE
Use exact padding for the bottom of the footer

### DIFF
--- a/resources/skins.femiwiki/interface.less
+++ b/resources/skins.femiwiki/interface.less
@@ -473,13 +473,14 @@ hr#content-end-bar {
 
 // Footer
 .mw-footer {
+  overflow: hidden;
   box-sizing: border-box;
   .content-horizontal-padding();
   padding-top: 0.8rem;
-  padding-bottom: 0;
+  padding-bottom: 1.6rem;
 
   max-width: @content-width;
-  margin: 0 auto 3.2rem;
+  margin: 0 auto;
 
   ul {
     font-size: 0.714rem;


### PR DESCRIPTION
The margin-bottom previously used was added to the height of the footer, but the height did not include its children; making the actual margin arbitrary.

Previous:
![image](https://user-images.githubusercontent.com/28209361/145716825-034752d3-813b-490f-bdb6-b10269a7baaf.png)

This changes it to:
![image](https://user-images.githubusercontent.com/28209361/145716897-3c1ffdb3-a4ff-4cfe-a7c2-c754ba37215a.png)
