### PR TITLE
darkmode: Set background-color of body and html

### DIFF
--- a/resources/skins.femiwiki.moduleSkinStyles/ext.DarkMode.styles.less
+++ b/resources/skins.femiwiki.moduleSkinStyles/ext.DarkMode.styles.less
@@ -14,3 +14,12 @@
     color: @color-link;
   }
 }
+
+// Set explicit background-color to prepare the inversion.
+// https://github.com/femiwiki/FemiwikiSkin/issues/397
+html.client-dark-mode,
+// Set body element also, as the inversion is not applied to the html element on Firefox properly.
+// https://bugzilla.mozilla.org/show_bug.cgi?id=1682083
+html.client-dark-mode body {
+  background-color: whitesmoke;
+}


### PR DESCRIPTION
Set explicit background-color of body element and html element to prepare the inversion by DarkMode.

Thanks to @saschanaz for reporting this bug and identiying the ticket of the bug on Firefox.

Fixes #397