### PR TITLE
Do not hide the content of the footer; Apply the child ul

### DIFF
--- a/resources/skins.femiwiki/interface.less
+++ b/resources/skins.femiwiki/interface.less
@@ -483,6 +483,7 @@ hr#content-end-bar {
   margin: 0 auto;
 
   ul {
+    overflow: hidden;
     font-size: 0.714rem;
     margin: 0;
     padding: 0;

--- a/resources/skins.femiwiki/interface.less
+++ b/resources/skins.femiwiki/interface.less
@@ -473,7 +473,6 @@ hr#content-end-bar {
 
 // Footer
 .mw-footer {
-  overflow: hidden;
   box-sizing: border-box;
   .content-horizontal-padding();
   padding-top: 0.8rem;


### PR DESCRIPTION
Resolves that Special:Search has a misaligned footer.

![image](https://user-images.githubusercontent.com/28209361/146369676-27394263-1909-485c-98cc-36f39c23f5eb.png)
