### PR TITLE
Feature flag link class

### DIFF
--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -285,7 +285,11 @@ class Hooks implements \MediaWiki\Linker\Hook\HtmlPageLinkRendererBeginHook {
 			$customAttribs['class'] = '';
 		}
 
-		$customAttribs['class'] .= 'fw-link';
+		$config = MediaWikiServices::getInstance()->getService( 'ConfigFactory' )
+			->makeConfig( 'femiwiki' );
+		if ( $config->get( 'FemiwikiAddLinkClass' ) ) {
+			$customAttribs['class'] .= 'fw-link';
+		}
 		return true;
 	}
 }

--- a/includes/SmallElementsHooks.php
+++ b/includes/SmallElementsHooks.php
@@ -37,6 +37,9 @@ class SmallElementsHooks implements
 	 * @inheritDoc
 	 */
 	public function onOutputPageBodyAttributes( $out, $sk, &$bodyAttrs ): void {
+		if ( $sk->getSkinName() !== 'femiwiki' ) {
+			return;
+		}
 		$user = $sk->getUser();
 		$registered = $user->isRegistered();
 		$config = $sk->getConfig();

--- a/includes/SmallElementsHooks.php
+++ b/includes/SmallElementsHooks.php
@@ -37,7 +37,7 @@ class SmallElementsHooks implements
 	 * @inheritDoc
 	 */
 	public function onOutputPageBodyAttributes( $out, $sk, &$bodyAttrs ): void {
-		if ( $sk->getSkinName() !== 'femiwiki' ) {
+		if ( $sk->getSkinName() !== Constants::SKIN_NAME ) {
 			return;
 		}
 		$user = $sk->getUser();

--- a/skin.json
+++ b/skin.json
@@ -10,6 +10,9 @@
   "requires": {
     "MediaWiki": ">= 1.37.0"
   },
+  "ConfigRegistry": {
+    "femiwiki": "GlobalVarConfig::newInstance"
+  },
   "ValidSkinNames": {
     "femiwiki": {
       "displayname": "Femiwiki",
@@ -197,6 +200,7 @@
     "OutputPageBodyAttributes": "SmallElements"
   },
   "config": {
+    "FemiwikiAddLinkClass": { "value": false },
     "FemiwikiFirebaseKey": { "value": "" },
     "FemiwikiFacebookAppId": { "value": "" },
     "FemiwikiTwitterAccount": { "value": false },


### PR DESCRIPTION
Hey there! I'm getting setup with Femiwiki locally (lots of great stuff happening here - thank you for innovating!!!)

However, with FemiWiki installed I can't currently run MediaWiki integration tests (phpunit). This happens because of the class unconditionally added in this hook so I need some way to turn this off. Hope this patch is acceptable!