### PR TITLE
Drop wgFemiwikiFacebookAppId and wgFemiwikiTwitterAccount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ Versions and bullets are arranged chronologically from latest to oldest.
 
 ## Unreleased version
 
-- `$wgFemiwikiFacebookAppId` and `$wgFemiwikiTwitterAccount` configuration variables are removed. If you still need to use this feature, please see [https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:WikiSEO](Extension:CategoryExplorer).
+- `$wgFemiwikiFacebookAppId` and `$wgFemiwikiTwitterAccount` configuration variables are removed. If you still need to use this feature, please see [Extension:WikiSEO](https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:WikiSEO).
 - The default value of `$wgFemiwikiLegacySmallElementsForAnonymousUser` is now `false`.
 
 ## Previous Releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@ Versions and bullets are arranged chronologically from latest to oldest.
 
 ## Unreleased version
 
-- `$wgFemiwikiFacebookAppId` and `$wgFemiwikiTwitterAccount` configuration variables are removed. If you still need to use
-  this feature, please see [https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:WikiSEO](Extension:CategoryExplorer).
+- `$wgFemiwikiFacebookAppId` and `$wgFemiwikiTwitterAccount` configuration variables are removed. If you still need to use this feature, please see [https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:WikiSEO](Extension:CategoryExplorer).
 - The default value of `$wgFemiwikiLegacySmallElementsForAnonymousUser` is now `false`.
 
 ## Previous Releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,13 @@ Versions and bullets are arranged chronologically from latest to oldest.
 
 ## Unreleased version
 
+- `$wgFemiwikiFacebookAppId` and `$wgFemiwikiTwitterAccount` configuration variables are removed. If you still need to use
+  this feature, please see [https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:WikiSEO](Extension:CategoryExplorer).
 - The default value of `$wgFemiwikiLegacySmallElementsForAnonymousUser` is now `false`.
 
 ## Previous Releases
 
+- [REL1_38](https://github.com/femiwiki/FemiwikiSkin/blob/REL1_38/CHANGELOG.md)
 - [REL1_37](https://github.com/femiwiki/FemiwikiSkin/blob/REL1_37/CHANGELOG.md)
 - [REL1_36](https://github.com/femiwiki/FemiwikiSkin/blob/REL1_36/CHANGELOG.md)
 - [REL1_35](https://github.com/femiwiki/FemiwikiSkin/blob/REL1_35/CHANGELOG.md)

--- a/i18n/ar.json
+++ b/i18n/ar.json
@@ -9,6 +9,5 @@
 	"skin-femiwiki-page-menu-tooltip": "القائمة",
 	"skin-femiwiki-share-tooltip": "شارك هذه المادة",
 	"skin-femiwiki-share-dismiss": "رفض",
-	"skin-femiwiki-share-facebook": "فيسبوك",
 	"skin-femiwiki-share-twitter": "تويتر"
 }

--- a/i18n/ast.json
+++ b/i18n/ast.json
@@ -9,6 +9,5 @@
 	"skin-femiwiki-page-menu-tooltip": "Menú",
 	"skin-femiwiki-share-tooltip": "Compartir esti artículu",
 	"skin-femiwiki-share-dismiss": "Descartar",
-	"skin-femiwiki-share-facebook": "Facebook",
 	"skin-femiwiki-share-twitter": "Twitter"
 }

--- a/i18n/blk.json
+++ b/i18n/blk.json
@@ -8,7 +8,6 @@
 	"skin-femiwiki-page-menu-tooltip": "မီနူး",
 	"skin-femiwiki-share-tooltip": "ဖန်းဖြယ် လိတ်မဲ့ငါယို",
 	"skin-femiwiki-share-dismiss": "လွတ်ꩻ",
-	"skin-femiwiki-share-facebook": "ဖေ့ဗိုတ်",
 	"skin-femiwiki-share-twitter": "တွီိတာ",
 	"skin-femiwiki-desktop-switch-canceled": "မွဉ်းဖျင်မုꩻ ကုဲင်ထိုꩻလဲဉ်း။"
 }

--- a/i18n/bn.json
+++ b/i18n/bn.json
@@ -6,6 +6,5 @@
 	},
 	"skin-femiwiki-page-menu-tooltip": "মেনু",
 	"skin-femiwiki-share-dismiss": "খারিজ",
-	"skin-femiwiki-share-facebook": "ফেসবুক",
 	"skin-femiwiki-share-twitter": "টুইটার"
 }

--- a/i18n/ca.json
+++ b/i18n/ca.json
@@ -10,7 +10,6 @@
 	"skin-femiwiki-page-menu-tooltip": "Menú",
 	"skin-femiwiki-share-tooltip": "Comparteix aquest article",
 	"skin-femiwiki-share-dismiss": "Descarta",
-	"skin-femiwiki-share-facebook": "Facebook",
 	"skin-femiwiki-share-twitter": "Twitter",
 	"femiwiki.css": "/ * El CSS que es col·loqui aquí afectarà l'aparença de Femiwiki d'altres usuàries * /",
 	"femiwiki.js": "/* Qualsevol codi JavaScript que es posi aquí es carregarà per a les usuàries que utilitzin l'aparença Femiwiki */",

--- a/i18n/da.json
+++ b/i18n/da.json
@@ -6,6 +6,5 @@
 	},
 	"skin-femiwiki-page-menu-tooltip": "Menu",
 	"skin-femiwiki-share-tooltip": "Del denne artikel",
-	"skin-femiwiki-share-facebook": "Facebook",
 	"skin-femiwiki-share-twitter": "Twitter"
 }

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -10,7 +10,6 @@
 	"skin-femiwiki-page-menu-tooltip": "Menü",
 	"skin-femiwiki-share-tooltip": "Diesen Artikel teilen",
 	"skin-femiwiki-share-dismiss": "Schließen",
-	"skin-femiwiki-share-facebook": "Facebook",
 	"skin-femiwiki-share-twitter": "Twitter",
 	"femiwiki.css": "/* Das folgende CSS wird für Benutzer der Femwiki-Benutzeroberfläche geladen. */",
 	"femiwiki.js": "/* Das folgende JavaScript wird für Benutzer der Benutzeroberfläche Femwiki geladen. */",

--- a/i18n/diq.json
+++ b/i18n/diq.json
@@ -11,7 +11,6 @@
 	"skin-femiwiki-page-menu-tooltip": "Menu",
 	"skin-femiwiki-share-tooltip": "Enê meqaley bıvılaynê",
 	"skin-femiwiki-share-dismiss": "Red ke",
-	"skin-femiwiki-share-facebook": "Facebook",
 	"skin-femiwiki-share-twitter": "Twitter",
 	"femiwiki.css": "/* Debiyaye CSS, Skinê Femiwiki rê tesir do bıkero */",
 	"femiwiki.js": "/* Her JavaScript karberanê Femiwiki de skin gurenayış de tiya de bar bo*/",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -7,7 +7,6 @@
   "skin-femiwiki-page-menu-tooltip": "Menu",
   "skin-femiwiki-share-tooltip": "Share this article",
   "skin-femiwiki-share-dismiss": "Dismiss",
-  "skin-femiwiki-share-facebook": "Facebook",
   "skin-femiwiki-share-twitter": "Twitter",
   "skin-femiwiki-xeicon-map.json": "{\n    \"pt-createaccount\": \"user-plus\",\n    \"pt-login\": \"log-in\",\n    \"pt-userpage\": \"profile\",\n    \"pt-notifications-all\": \"bell\",\n    \"pt-mytalk\": \"forum\",\n    \"pt-preferences\": \"cog\",\n    \"pt-watchlist\": \"star\",\n    \"pt-mycontris\": \"list\",\n    \"pt-logout\": \"log-out\",\n    \"t-whatlinkshere\": \"paper\",\n    \"t-recentchangeslinked\": \"clock-o\",\n    \"t-print\": \"print\",\n    \"t-permalink\": \"link\",\n    \"t-info\": \"info\",\n    \"t-cite\": \"link-insert\",\n    \"t-wikibase\": \"barcode\",\n    \"ca-delete\": \"trash\",\n    \"ca-move\": \"long-arrow-right\",\n    \"ca-protect\": \"lock\",\n    \"ca-unprotect\": \"unlock\",\n    \"feedlinks\": \"rss-square\"\n}",
   "femiwiki.css": "/* CSS placed here will affect users of the Femiwiki skin */",

--- a/i18n/es.json
+++ b/i18n/es.json
@@ -6,6 +6,5 @@
 		]
 	},
 	"skin-femiwiki-page-menu-tooltip": "Menú",
-	"skin-femiwiki-share-facebook": "Facebook",
 	"skin-femiwiki-share-twitter": "Twitter"
 }

--- a/i18n/fa.json
+++ b/i18n/fa.json
@@ -8,7 +8,6 @@
 	},
 	"skin-femiwiki-page-menu-tooltip": "منو",
 	"skin-femiwiki-share-dismiss": "بگذریم",
-	"skin-femiwiki-share-facebook": "فیس‌بوک",
 	"skin-femiwiki-share-twitter": "توئیتر",
 	"prefs-femiwiki-large-elements-label": "استفاده از عناصر بزرگ‌تر",
 	"prefs-femiwiki-large-elements-help": "این گزینه به شما امکان پیش‌نمایش عناصر بزرگ‌تر را می‌دهد. عناصر موجود در تصویر با نمونه‌هایی بزرگ‌تر جایگزین می‌شوند."

--- a/i18n/fi.json
+++ b/i18n/fi.json
@@ -9,6 +9,5 @@
 	"skin-femiwiki-page-menu-tooltip": "Valikko",
 	"skin-femiwiki-share-tooltip": "Jaa tämä artikkeli",
 	"skin-femiwiki-share-dismiss": "Hylkää",
-	"skin-femiwiki-share-facebook": "Facebook",
 	"skin-femiwiki-share-twitter": "Twitter"
 }

--- a/i18n/fr.json
+++ b/i18n/fr.json
@@ -12,7 +12,6 @@
 	"skin-femiwiki-page-menu-tooltip": "Menu",
 	"skin-femiwiki-share-tooltip": "Partager cet article",
 	"skin-femiwiki-share-dismiss": "Ignorer",
-	"skin-femiwiki-share-facebook": "Facebook",
 	"skin-femiwiki-share-twitter": "Twitter",
 	"femiwiki.css": "/* Le CSS placé ici affectera les utilisateurs de l’habillage Fémiwiki */",
 	"femiwiki.js": "/* Tout code JavaScript placé ici sera chargé avec les pages accédées par les utilisateurs de l’habillage Fémiwiki */",

--- a/i18n/he.json
+++ b/i18n/he.json
@@ -9,7 +9,6 @@
 	"skin-femiwiki-page-menu-tooltip": "תפריט",
 	"skin-femiwiki-share-tooltip": "שיתוף הערך הזה",
 	"skin-femiwiki-share-dismiss": "סגירה",
-	"skin-femiwiki-share-facebook": "פייסבוק",
 	"skin-femiwiki-share-twitter": "טוויטר",
 	"skin-femiwiki-desktop-switch-confirm": "עריכה במצב נייד עדיין לא נתמכת. האם {{GENDER:|תרצה|תרצי}} לעבור למצב מחשבים?",
 	"skin-femiwiki-desktop-switch-canceled": "העריכה מבוטלת.",

--- a/i18n/ia.json
+++ b/i18n/ia.json
@@ -9,7 +9,6 @@
 	"skin-femiwiki-page-menu-tooltip": "Menu",
 	"skin-femiwiki-share-tooltip": "Condivider iste articulo",
 	"skin-femiwiki-share-dismiss": "Clauder",
-	"skin-femiwiki-share-facebook": "Facebook",
 	"skin-femiwiki-share-twitter": "Twitter",
 	"femiwiki.css": "/* Le CSS placiate hic afficera le usatores del apparentia Femiwiki */",
 	"femiwiki.js": "/* Omne JavaScript hic se executara pro le usatores del apparentia Femiwiki */",

--- a/i18n/ja.json
+++ b/i18n/ja.json
@@ -9,7 +9,6 @@
 	},
 	"skin-femiwiki-page-menu-tooltip": "メニュー",
 	"skin-femiwiki-share-dismiss": "閉じる",
-	"skin-femiwiki-share-facebook": "Facebook",
 	"skin-femiwiki-share-twitter": "Twitter",
 	"femiwiki.css": "/* ここに記述したCSSはFemiwiki skinの利用者に影響します */",
 	"femiwiki.js": "/* ここにあるすべてのJavaScriptは、Femiwiki skinを使用している利用者に対して読み込まれます */",

--- a/i18n/ko.json
+++ b/i18n/ko.json
@@ -10,7 +10,6 @@
 	"skin-femiwiki-page-menu-tooltip": "메뉴",
 	"skin-femiwiki-share-tooltip": "이 문서 공유하기",
 	"skin-femiwiki-share-dismiss": "숨기기",
-	"skin-femiwiki-share-facebook": "페이스북",
 	"skin-femiwiki-share-twitter": "트위터",
 	"skin-femiwiki-desktop-switch-confirm": "모바일 보기에서는 이 편집이 아직 지원되지 않습니다. 데스크톱 보기로 전환하시겠습니까?",
 	"skin-femiwiki-desktop-switch-canceled": "편집이 취소되었습니다.",

--- a/i18n/lb.json
+++ b/i18n/lb.json
@@ -5,7 +5,6 @@
 		]
 	},
 	"skin-femiwiki-page-menu-tooltip": "Menü",
-	"skin-femiwiki-share-facebook": "Facebook",
 	"skin-femiwiki-share-twitter": "Twitter",
 	"skin-femiwiki-desktop-switch-canceled": "Änneren ass ofgebrach."
 }

--- a/i18n/lt.json
+++ b/i18n/lt.json
@@ -5,6 +5,5 @@
 		]
 	},
 	"skin-femiwiki-share-dismiss": "Atmesti",
-	"skin-femiwiki-share-facebook": "Facebook",
 	"skin-femiwiki-share-twitter": "Twitter"
 }

--- a/i18n/mk.json
+++ b/i18n/mk.json
@@ -9,7 +9,6 @@
 	"skin-femiwiki-page-menu-tooltip": "Мени",
 	"skin-femiwiki-share-tooltip": "Сподели ја статијава",
 	"skin-femiwiki-share-dismiss": "Тргни",
-	"skin-femiwiki-share-facebook": "Фејсбук",
 	"skin-femiwiki-share-twitter": "Твитер",
 	"femiwiki.css": "/* Тука поставениот CSS ќе се применува врз корисниците на рувото „Фемвики“ */",
 	"femiwiki.js": "/* Тука поставениот JavaScript ќе се применува врз корисниците на рувото „Фемвики“ */",

--- a/i18n/my.json
+++ b/i18n/my.json
@@ -6,6 +6,5 @@
 	},
 	"skin-femiwiki-page-menu-tooltip": "မီးနူး",
 	"skin-femiwiki-share-tooltip": "ဤစာမျက်နှာအား မျှဝေရန်",
-	"skin-femiwiki-share-facebook": "ဖေ့ဘုတ်",
 	"skin-femiwiki-share-twitter": "တွတ်တာ"
 }

--- a/i18n/nb.json
+++ b/i18n/nb.json
@@ -9,7 +9,6 @@
 	"skin-femiwiki-page-menu-tooltip": "Meny",
 	"skin-femiwiki-share-tooltip": "Del denne artikkelen",
 	"skin-femiwiki-share-dismiss": "Lukk",
-	"skin-femiwiki-share-facebook": "Facebook",
 	"skin-femiwiki-share-twitter": "Twitter",
 	"femiwiki.css": "/* CSS i denne fila vil gjelde alle som bruker drakta Femiwiki */",
 	"femiwiki.js": "/* Javascript i denne fila vil gjelde for brukere av drakta Femiwiki */",

--- a/i18n/nl.json
+++ b/i18n/nl.json
@@ -10,7 +10,6 @@
 	"skin-femiwiki-page-menu-tooltip": "Menu",
 	"skin-femiwiki-share-tooltip": "Deel dit artikel",
 	"skin-femiwiki-share-dismiss": "Sluiten",
-	"skin-femiwiki-share-facebook": "Facebook",
 	"skin-femiwiki-share-twitter": "Twitter",
 	"femiwiki.css": "/* CSS die hier wordt geplaatst heeft alleen invloed op het uiterlijk Femiwiki */",
 	"femiwiki.js": "/* JavaScript die hier wordt geplaatst heeft alleen invloed op gebruikers die het uiterlijk Femiwiki gebruiken */",

--- a/i18n/pt-br.json
+++ b/i18n/pt-br.json
@@ -10,7 +10,6 @@
 	"skin-femiwiki-page-menu-tooltip": "Menu",
 	"skin-femiwiki-share-tooltip": "Falha ao escrever uma sanção.",
 	"skin-femiwiki-share-dismiss": "Ignorar",
-	"skin-femiwiki-share-facebook": "Facebook",
 	"skin-femiwiki-share-twitter": "Twitter",
 	"femiwiki.css": "/* CSS colocado aqui afetará os usuários do tema Femiwiki */",
 	"femiwiki.js": "/* Qualquer JavaScript aqui será carregado para usuários que usam o tema Femiwiki */",

--- a/i18n/pt.json
+++ b/i18n/pt.json
@@ -9,7 +9,6 @@
 	"skin-femiwiki-page-menu-tooltip": "Menu",
 	"skin-femiwiki-share-tooltip": "Partilhar este artigo",
 	"skin-femiwiki-share-dismiss": "Ignorar",
-	"skin-femiwiki-share-facebook": "Facebook",
 	"skin-femiwiki-share-twitter": "Twitter",
 	"femiwiki.css": "/* Código CSS colocado aqui afetará os utilizadores do tema Femiwiki */",
 	"femiwiki.js": "/* Código Javascript colocado aqui será carregado para utilizadores do tema Femiwiki */",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -11,7 +11,6 @@
 	"skin-femiwiki-page-menu-tooltip": "Tooltip for button used to expand/collapse menu of a page",
 	"skin-femiwiki-share-tooltip": "Tooltip for button to share a article",
 	"skin-femiwiki-share-dismiss": "Label for share dialog dismiss button",
-	"skin-femiwiki-share-facebook": "Label for button that posts to Facebook",
 	"skin-femiwiki-share-twitter": "Label for button that posts to Twitter",
 	"skin-femiwiki-xeicon-map.json": "{{optional}}",
 	"femiwiki.css": "{{Optional}}",

--- a/i18n/roa-tara.json
+++ b/i18n/roa-tara.json
@@ -9,7 +9,6 @@
 	"skin-femiwiki-page-menu-tooltip": "Menù",
 	"skin-femiwiki-share-tooltip": "Condivide sta vôsce",
 	"skin-femiwiki-share-dismiss": "Scitte",
-	"skin-femiwiki-share-facebook": "Feisbuc",
 	"skin-femiwiki-share-twitter": "Tuitter",
 	"femiwiki.css": "/* 'U CSS ca se iacchie aqquà 'u 'ndrucane le utinde d'a masckere Femiwiki */",
 	"femiwiki.js": "/* Ogne JavaScript aqquà avène carecate pe le utinde ca ausane 'a masckere Femiwiki */",

--- a/i18n/ru.json
+++ b/i18n/ru.json
@@ -10,7 +10,6 @@
 	"skin-femiwiki-page-menu-tooltip": "Меню",
 	"skin-femiwiki-share-tooltip": "Поделиться этой статьёй",
 	"skin-femiwiki-share-dismiss": "Отменить",
-	"skin-femiwiki-share-facebook": "Facebook",
 	"skin-femiwiki-share-twitter": "Twitter",
 	"femiwiki.css": "/* Размещённый здесь CSS будет применяться к теме оформления Femiwiki */",
 	"femiwiki.js": "/* Размещённый здесь код JavaScript будет загружаться пользователям, использующим тему оформления Femiwiki */",

--- a/i18n/scn.json
+++ b/i18n/scn.json
@@ -6,6 +6,5 @@
 	},
 	"femiwiki-desc": "Peddi Femiwiki",
 	"skin-femiwiki-page-menu-tooltip": "Menu",
-	"skin-femiwiki-share-facebook": "Facebook",
 	"skin-femiwiki-share-twitter": "Twitter"
 }

--- a/i18n/sh.json
+++ b/i18n/sh.json
@@ -7,6 +7,5 @@
 	"skin-femiwiki-page-menu-tooltip": "Meni",
 	"skin-femiwiki-share-tooltip": "Podijeli ovaj članak",
 	"skin-femiwiki-share-dismiss": "Odbaci",
-	"skin-femiwiki-share-facebook": "Facebook",
 	"skin-femiwiki-share-twitter": "Twitter"
 }

--- a/i18n/sr-ec.json
+++ b/i18n/sr-ec.json
@@ -9,6 +9,5 @@
 	"skin-femiwiki-page-menu-tooltip": "Мени",
 	"skin-femiwiki-share-tooltip": "Подели овај чланак",
 	"skin-femiwiki-share-dismiss": "Одбаци",
-	"skin-femiwiki-share-facebook": "Фејсбук",
 	"skin-femiwiki-share-twitter": "Твитер"
 }

--- a/i18n/sr-el.json
+++ b/i18n/sr-el.json
@@ -6,6 +6,5 @@
 	"skin-femiwiki-page-menu-tooltip": "Meni",
 	"skin-femiwiki-share-tooltip": "Podeli ovaj članak",
 	"skin-femiwiki-share-dismiss": "Odbaci",
-	"skin-femiwiki-share-facebook": "Fejsbuk",
 	"skin-femiwiki-share-twitter": "Tviter"
 }

--- a/i18n/sv.json
+++ b/i18n/sv.json
@@ -10,7 +10,6 @@
 	"skin-femiwiki-page-menu-tooltip": "Meny",
 	"skin-femiwiki-share-tooltip": "Dela denna artikel",
 	"skin-femiwiki-share-dismiss": "Stäng",
-	"skin-femiwiki-share-facebook": "Facebook",
 	"skin-femiwiki-share-twitter": "Twitter",
 	"femiwiki.css": "/* CSS som skrivs här kommer att påverka alla användare av utseendet Femiwiki */",
 	"femiwiki.js": "/* All JavaScript här kommer att läsas in för de som använder utseendet Femiwiki */",

--- a/i18n/ta.json
+++ b/i18n/ta.json
@@ -4,6 +4,5 @@
 			"ElangoRamanujam"
 		]
 	},
-	"skin-femiwiki-share-facebook": "ஃபேஸ்புக்",
 	"skin-femiwiki-share-twitter": "ட்விட்டர்"
 }

--- a/i18n/ti.json
+++ b/i18n/ti.json
@@ -5,6 +5,5 @@
 		]
 	},
 	"skin-femiwiki-share-dismiss": "ስጎግ",
-	"skin-femiwiki-share-facebook": "ፈይስቡክ",
 	"skin-femiwiki-share-twitter": "ትዊተር"
 }

--- a/i18n/tr.json
+++ b/i18n/tr.json
@@ -11,7 +11,6 @@
 	"skin-femiwiki-page-menu-tooltip": "Menü",
 	"skin-femiwiki-share-tooltip": "Bu maddeyi paylaş",
 	"skin-femiwiki-share-dismiss": "Kapat",
-	"skin-femiwiki-share-facebook": "Facebook",
 	"skin-femiwiki-share-twitter": "Twitter",
 	"femiwiki.css": "/* Buraya yerleştirilen CSS, Femiwiki görünümünün kullanıcılarını etkileyecek */",
 	"femiwiki.js": "/* Buradaki herhangi bir JavaScript, Femiwiki görünümünü kullanan kullanıcılar için yüklenecektir. */",

--- a/i18n/tt-cyrl.json
+++ b/i18n/tt-cyrl.json
@@ -5,5 +5,4 @@
 		]
 	},
 	"skin-femiwiki-page-menu-tooltip": "Меню",
-	"skin-femiwiki-share-facebook": "Facebook"
 }

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -12,7 +12,6 @@
 	"skin-femiwiki-page-menu-tooltip": "Меню",
 	"skin-femiwiki-share-tooltip": "Поширити цю статтю",
 	"skin-femiwiki-share-dismiss": "Скасувати",
-	"skin-femiwiki-share-facebook": "Facebook",
 	"skin-femiwiki-share-twitter": "Twitter",
 	"femiwiki.css": "/* Розміщений тут CSS-код буде використаний в темі оформлення Femiwiki */",
 	"femiwiki.js": "/* Розміщений тут код JavaScript буде завантажений для всіх користувачів, що використовують тему оформлення Femiwiki */",

--- a/i18n/zh-hans.json
+++ b/i18n/zh-hans.json
@@ -11,7 +11,6 @@
 	"skin-femiwiki-page-menu-tooltip": "菜单",
 	"skin-femiwiki-share-tooltip": "分享这篇文章",
 	"skin-femiwiki-share-dismiss": "关闭",
-	"skin-femiwiki-share-facebook": "脸书",
 	"skin-femiwiki-share-twitter": "推特",
 	"femiwiki.css": "/* 这里放置的CSS将影响使用Femiwiki皮肤的用户 */",
 	"femiwiki.js": "/* 这里的任何JavaScript将为使用Femiwiki皮肤的用户加载 */",

--- a/i18n/zh-hant.json
+++ b/i18n/zh-hant.json
@@ -10,7 +10,6 @@
 	"skin-femiwiki-page-menu-tooltip": "選單",
 	"skin-femiwiki-share-tooltip": "分享此條目",
 	"skin-femiwiki-share-dismiss": "去除",
-	"skin-femiwiki-share-facebook": "Facebook",
 	"skin-femiwiki-share-twitter": "Twitter",
 	"femiwiki.css": "/* 此處的 CSS 會影響使用 Femiwiki 外觀的使用者 */",
 	"femiwiki.js": "/* 此處的任何 JavaScript 都會在使用者使用 Femiwiki 外觀時載入 */",

--- a/includes/Constants.php
+++ b/includes/Constants.php
@@ -21,8 +21,6 @@ final class Constants {
 	/** @var string */
 	public const CONFIG_ADD_THIS_ID = 'FemiwikiAddThisId';
 	/** @var string */
-	public const CONFIG_FACEBOOK_APP_ID = 'FemiwikiFacebookAppId';
-	/** @var string */
 	public const CONFIG_FIREBASE_KEY = 'FemiwikiFirebaseKey';
 	/** @var string */
 	public const CONFIG_HEAD_ITEMS = 'FemiwikiHeadItems';
@@ -32,6 +30,4 @@ final class Constants {
 	public const CONFIG_KEY_SMALL_ELEMENTS_FOR_ANONYMOUS_USER = 'FemiwikiLegacySmallElementsForAnonymousUser';
 	/** @var string */
 	public const CONFIG_KEY_USE_PAGE_LANG_FOR_HEADING = 'FemiwikiUsePageLangForHeading';
-	/** @var string */
-	public const CONFIG_TWITTER_ACCOUNT = 'FemiwikiTwitterAccount';
 }

--- a/includes/HookHandler/DefaultHooks.php
+++ b/includes/HookHandler/DefaultHooks.php
@@ -28,11 +28,9 @@ class DefaultHooks implements
 	 */
 	public function onResourceLoaderGetConfigVars( array &$vars, $skin, Config $config ): void {
 		$firebaseKey = $config->get( Constants::CONFIG_FIREBASE_KEY );
-		$facebookAppId = $config->get( Constants::CONFIG_FACEBOOK_APP_ID );
 		$addThisId = $config->get( Constants::CONFIG_ADD_THIS_ID );
 
 		$vars['wgFemiwikiFirebaseKey'] = $firebaseKey;
-		$vars['wgFemiwikiFacebookAppId'] = $facebookAppId;
 		if ( $addThisId ) {
 			$vars['wgFemiwikiUseAddThis'] = true;
 			if ( is_array( $addThisId ) && isset( $addThisId['tool'] ) ) {

--- a/includes/SkinFemiwiki.php
+++ b/includes/SkinFemiwiki.php
@@ -287,11 +287,6 @@ class SkinFemiwiki extends SkinMustache {
 	public function initPage( OutputPage $out ) {
 		$out->addMeta( 'viewport', 'width=device-width, initial-scale=1.0' );
 
-		$twitter = $this->getConfig()->get( Constants::CONFIG_TWITTER_ACCOUNT );
-		if ( $twitter ) {
-			$out->addMeta( 'twitter:site', "@$twitter" );
-		}
-
 		// Favicons
 		$headItems = $this->getConfig()->get( Constants::CONFIG_HEAD_ITEMS );
 		if ( $headItems ) {

--- a/resources/skins.femiwiki.share.ui/mw.fw.ShareDialog.js
+++ b/resources/skins.femiwiki.share.ui/mw.fw.ShareDialog.js
@@ -11,7 +11,6 @@
     this.useAddThis = config.useAddThis;
     this.addThisToolId = config.addThisToolId;
     this.firebaseKey = config.firebaseKey;
-    this.facebookAppId = config.facebookAppId;
 
     // Parent constructor
     mw.fw.ShareDialog.super.call(this, config);
@@ -45,21 +44,6 @@
       addthis.layers.refresh();
     } else {
       var items = [];
-      if (this.facebookAppId) {
-        this.facebookButton = new OO.ui.ButtonWidget({
-          framed: false,
-          icon: 'newWindow',
-          label: mw.msg('skin-femiwiki-share-facebook'),
-        });
-
-        items.push(this.facebookButton);
-
-        // Connect onClick function
-        this.facebookButton.connect(this, {
-          click: 'onFacebookButtonClick',
-        });
-        this.facebookButton.$element.addClass('mw-fw-ui-facebookButton');
-      }
       this.twitterButton = new OO.ui.ButtonWidget({
         framed: false,
         icon: 'newWindow',
@@ -117,16 +101,6 @@
       .next(function () {
         this.urlWidget.select();
       }, this);
-  };
-
-  mw.fw.ShareDialog.prototype.onFacebookButtonClick = function () {
-    FB.ui(
-      {
-        method: 'share',
-        href: this.longUrl,
-      },
-      function (response) {}
-    );
   };
 
   mw.fw.ShareDialog.prototype.updateUrl = function (url) {

--- a/resources/skins.femiwiki.share/init.js
+++ b/resources/skins.femiwiki.share/init.js
@@ -3,7 +3,7 @@
 
   function init() {
     OO.ui.infuse($('#p-share')).on('click', function () {
-      var windowManager, facebookAppId, shareDialog;
+      var windowManager, shareDialog;
       var firebaseKey = firebaseKey || mw.config.get('wgFemiwikiFirebaseKey');
       var useAddThis = useAddThis || mw.config.get('wgFemiwikiUseAddThis');
       var addThisToolId =
@@ -22,9 +22,6 @@
             },
           },
         };
-      } else {
-        facebookAppId =
-          facebookAppId || mw.config.get('wgFemiwikiFacebookAppId');
       }
 
       mw.loader.using(['skins.femiwiki.share.ui']).done(function () {
@@ -34,33 +31,8 @@
             useAddThis: useAddThis,
             addThisToolId: addThisToolId,
             firebaseKey: firebaseKey,
-            facebookAppId: facebookAppId,
           });
           windowManager.addWindows([shareDialog]);
-        }
-
-        if (!useAddThis && facebookAppId) {
-          // Initialize Facebook SDK
-          window.fbAsyncInit = function () {
-            FB.init({
-              appId: facebookAppId,
-              autoLogAppEvents: true,
-              xfbml: true,
-              version: 'v4.0',
-            });
-          };
-          // below snippet is from https://developers.facebook.com/docs/php/howto/example_access_token_from_javascript
-          (function (d, s, id) {
-            var js,
-              fjs = d.getElementsByTagName(s)[0];
-            if (d.getElementById(id)) {
-              return;
-            }
-            js = d.createElement(s);
-            js.id = id;
-            js.src = 'https://connect.facebook.net/en_US/sdk.js';
-            fjs.parentNode.insertBefore(js, fjs);
-          })(document, 'script', 'facebook-jssdk');
         }
 
         windowManager.openWindow(shareDialog, {

--- a/skin.json
+++ b/skin.json
@@ -81,7 +81,6 @@
       "dependencies": ["skins.femiwiki.dm", "oojs", "oojs-ui-windows"],
       "messages": [
         "skin-femiwiki-share-dismiss",
-        "skin-femiwiki-share-facebook",
         "skin-femiwiki-share-twitter"
       ],
       "targets": ["desktop", "mobile"]
@@ -234,8 +233,6 @@
   "config": {
     "FemiwikiAddLinkClass": { "value": false },
     "FemiwikiFirebaseKey": { "value": "" },
-    "FemiwikiFacebookAppId": { "value": "" },
-    "FemiwikiTwitterAccount": { "value": false },
     "FemiwikiHeadItems": { "value": false },
     "FemiwikiAddThisId": { "value": false },
     "FemiwikiUsePageLangForHeading": { "value": true },


### PR DESCRIPTION
`$wgFemiwikiFacebookAppId` and `$wgFemiwikiTwitterAccount` configuration variables are removed. If you still need to use
  this feature, please see [https://www.mediawiki.org/wiki/Special:MyLanguage/Extension:WikiSEO](Extension:CategoryExplorer).