### PR TITLE
Replace the deprecated usages of checkboxhack

### DIFF
--- a/resources/@types/CheckboxHack.d.ts
+++ b/resources/@types/CheckboxHack.d.ts
@@ -1,17 +1,13 @@
 interface CheckboxHack {
-  updateAriaExpanded(checkbox: HTMLInputElement, button: HTMLElement): void;
+  updateAriaExpanded(checkbox: HTMLInputElement): void;
   bindUpdateAriaExpandedOnInput(
-    checkbox: HTMLInputElement,
-    button: HTMLElement
+    checkbox: HTMLInputElement
   ): CheckboxHackListeners;
   bindToggleOnClick(
     checkbox: HTMLInputElement,
     button: HTMLElement
   ): CheckboxHackListeners;
-  bindToggleOnSpaceEnter(
-    checkbox: HTMLInputElement,
-    button: HTMLElement
-  ): CheckboxHackListeners;
+  bindToggleOnEnter(checkbox: HTMLInputElement): CheckboxHackListeners;
   bindDismissOnClickOutside(
     window: Window,
     checkbox: HTMLInputElement,

--- a/resources/skins.femiwiki.js/skin.js
+++ b/resources/skins.femiwiki.js/skin.js
@@ -13,9 +13,9 @@
 function initCheckboxHack(checkbox, button) {
   if (checkbox instanceof HTMLInputElement && button) {
     checkboxHack.bindToggleOnClick(checkbox, button);
-    checkboxHack.bindUpdateAriaExpandedOnInput(checkbox, button);
-    checkboxHack.updateAriaExpanded(checkbox, button);
-    checkboxHack.bindToggleOnSpaceEnter(checkbox, button);
+    checkboxHack.bindUpdateAriaExpandedOnInput(checkbox);
+    checkboxHack.updateAriaExpanded(checkbox);
+    checkboxHack.bindToggleOnEnter(checkbox);
   }
 }
 


### PR DESCRIPTION
https://gerrit.wikimedia.org/g/mediawiki/core/+/ae82334289ff47a9e9c6dfd0dc2ad292d726d3f6/HISTORY#691:

```
* The `button` parameter for `bindUpdateAriaExpandedOnInput` and
  `updateAriaExpanded` in checkboxHack.js have been deprecated.
  `bindToggleOnSpaceEnter` has also been deprecated in favor of
  `bindToggleOnEnter`.
```