### PR TITLE
Fixes Class 'ResourceLoaderSkinModule' Not Found Error

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -17,7 +17,7 @@
   },
   "ResourceModules": {
     "skins.femiwiki": {
-      "class": "ResourceLoaderSkinModule",
+      "class": "MediaWiki\\ResourceLoader\\SkinModule",
       "features": {
         "content-media": true,
         "toc": false,
@@ -34,7 +34,7 @@
       ]
     },
     "skins.femiwiki.xeicon": {
-      "class": "ResourceLoaderSkinModule",
+      "class": "MediaWiki\\ResourceLoader\\SkinModule",
       "features": {
         "content-body": false,
         "toc": false


### PR DESCRIPTION
The alias ResourceLoaderSkinModule was dropped in favor of MediaWiki\\ResourceLoader\\SkinModule in

https://gerrit.wikimedia.org/r/c/mediawiki/core/+/994854

See: https://phabricator.wikimedia.org/T356563