### PR TITLE
fix: avoid fraction expression in Less

### DIFF
--- a/resources/variables.less
+++ b/resources/variables.less
@@ -58,8 +58,8 @@
 @color-alert-border: @color-secondary2;
 
 // Same colors as Codex's @background-color-button-quiet--*
-@button-background-color--hover: rgba(0, 24, 73, 7/255);
-@button-background-color--active: rgba(0, 36, 73, 21/255);
+@button-background-color--hover: rgba(0, 24, 73, 0.27);
+@button-background-color--active: rgba(0, 36, 73, 0.082);
 
 @opacity-icon: 65%;
 @padding-icon: 0.37142855rem;


### PR DESCRIPTION
Fixes this:
```
Error: [exception] [error] [{reqId}] {exception_url}   Less_Exception_Compiler: error evaluating function `rgba` color functions take numbers as parameters index: 1965 in variables.less on line 61, column 1
59| 
60| // Same colors as Codex's @background-color-button-quiet--*
61| @button-background-color--hover: rgba(0, 24, 73, 7/255);
62| @button-background-color--active: rgba(0, 36, 73, 21/255);
63| 
64| @opacity-icon: 65%; {"exception":{"currentFile":{"entryPath":"\/workspace\/src\/skins\/Femiwiki\/resources\/skins.femiwiki.moduleSkinStyles\/","entryUri":"\/workspace\/src\/skins\/Femiwiki\/resources\/skins.femiwiki.moduleSkinStyles\/","rootpath":"\/workspace\/src\/skins\/Femiwiki\/resources\/skins.femiwiki.moduleSkinStyles\/","currentDirectory":"\/workspace\/src\/skins\/Femiwiki\/resources\/","currentUri":"\/workspace\/src\/skins\/Femiwiki\/resources\/variables.less","filename":"\/workspace\/src\/skins\/Femiwiki\/resources\/variables.less","uri_root":"\/workspace\/src\/skins\/Femiwiki\/resources\/"},"index":1932},"exception_url":"[no req]","reqId":"b163b0d3f3c02a47907930ac","caught_by":"other"}
```