### PR TITLE
fix: Don't depend on the icon file from MediaWiki core

### DIFF
--- a/resources/skins.femiwiki/interface.less
+++ b/resources/skins.femiwiki/interface.less
@@ -357,17 +357,16 @@
       padding-left: 0;
 
       &:before {
-        background-image: /* @embed */ url(../../../../resources/src/mediawiki.helplink/images/helpNotice.svg);
-        background-position: center;
-        background-repeat: no-repeat;
+        font-size: @icon-size;
+        line-height: 1em;
+        color: black;
         opacity: @opacity-icon;
-        content: '';
+        font-family: 'xeicon' !important;
+        content: '\e9ad';
         display: block;
         position: absolute;
         top: @padding-icon;
         left: @padding-icon;
-        width: @icon-size;
-        height: @icon-size;
       }
     }
 


### PR DESCRIPTION
The result:

![image](https://github.com/user-attachments/assets/21a4f7e8-243d-4ddd-82f2-ea9ae7d3cda5)

and it was previously:

![image](https://github.com/user-attachments/assets/1f91a7ee-1f46-4aec-a904-67c26f6927ee)
