### PR TITLE
chore(package): add name field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,10 @@
 {
-  "name": "Femiwiki",
+  "name": "femiwiki",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "femiwiki",
       "dependencies": {
         "@femiwiki/ooui-femiwiki-theme": "https://github.com/femiwiki/OOUIFemiwikiTheme.git#REL1_42",
         "xeicon": "https://github.com/xpressengine/XEIcon.git#2.3.3"

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "femiwiki",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
name 필드가 없으니 package-lock 파일이 현재 경로 이름을 붙여 버리는 문제가 있어 이를 고정하기 위해 name 필드를 추가합니다