### PR TITLE
chore(tests/selenium): declare as commonjs

### DIFF
--- a/tests/selenium/package.json
+++ b/tests/selenium/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}


### PR DESCRIPTION
#803 이후로 최상위 경로에 `type: module`이 추가되었으나, ESM 지원은 wdio 8 에서 추가되었으므로 7을 쓰는 지금은 CJS로 선언해둘 필요가 있습니다.

현재 실패 중인 selenium 테스트를 고칩니다.