### PR TITLE
fix: Helplink

### DIFF
--- a/resources/skins.femiwiki/interface.less
+++ b/resources/skins.femiwiki/interface.less
@@ -370,6 +370,10 @@
       }
     }
 
+    .mw-indicators .mw-indicator#mw-indicator-mw-helplink a {
+      display: block;
+    }
+
     #p-menu-toggle:before {
       position: absolute;
       width: @icon-size;


### PR DESCRIPTION
Fixes this:
![image](https://github.com/user-attachments/assets/43f79358-f9fb-4beb-95ca-8c807078d094)

Overwrites https://gerrit.wikimedia.org/g/mediawiki/core/+/e6e72357d263969715ff6bcd6c361b83257b029e/resources/src/mediawiki.helplink/helplink.less#4