### PR TITLE
fix(styles): Cleanup thumb image

### DIFF
--- a/resources/variables.less
+++ b/resources/variables.less
@@ -583,62 +583,21 @@
   }
 
   // Image
-  div.thumb .thumbinner,
-  // For 2017 wikitext editor preview and VE
   figure[typeof~='mw:File/Thumb'],
   figure[typeof~='mw:Image/Thumb'] {
     font-size: 0.94rem;
-    max-width: 100%;
     background: none;
     border: none;
-    overflow: hidden;
-    padding: 3px;
-    text-align: center;
-    @media screen and (max-width: @width-breakpoint-mobile) {
+
+    .mw-file-element:not(.mw-broken-media) {
       border: none;
-      background-color: initial;
     }
 
-    .thumbimage {
+    figcaption {
       background: none;
       border: none;
-      vertical-align: middle;
-      @media screen and (max-width: @width-breakpoint-mobile) {
-        border: none;
-      }
-    }
-
-    .thumbcaption,
-    // For VE Preview
-    figcaption {
-      padding: 3px;
       font-size: 0.8836rem;
-      line-height: 1.23704rem;
       color: #888;
-      @media screen and (max-width: @width-breakpoint-mobile) {
-        text-align: center;
-      }
-    }
-  }
-
-  @media screen and (max-width: @width-breakpoint-mobile) {
-    div.thumb,
-    div.thumb .thumbinner {
-      margin: 0 auto;
-    }
-    div.thumb {
-      float: none;
-    }
-    figure[typeof~='mw:File/Thumb'],
-    figure[typeof~='mw:Image/Thumb'] {
-      // For 2017 wikitext editor preview
-      &,
-      // For VisualEditor
-      &.mw-halign-left,
-      &.mw-halign-right {
-        margin: 0 auto;
-        float: none;
-      }
     }
   }
 


### PR DESCRIPTION
Fixes #792

# Screenshots

## Before

Desktop:
![image](https://github.com/user-attachments/assets/55ea0fe8-3d47-4c68-b6fb-9f874c14d809)

Mobile:
![image](https://github.com/user-attachments/assets/c589fc32-38a6-41be-838b-05751f292510)


## After

Desktop:
![image](https://github.com/user-attachments/assets/3b64aa3f-5099-4370-848f-c227b6d5f268)

Mobile:
![image](https://github.com/user-attachments/assets/ab0cb906-a657-458f-bd70-196b6bcfbbb2)
