### PR TITLE
ci: pin quibble-action to main and declare dependencies explicitly

### DIFF
--- a/.github/workflows/extension-test.yml
+++ b/.github/workflows/extension-test.yml
@@ -43,37 +43,7 @@ jobs:
       - run: npm install
         if: matrix.stage == 'phpunit' || matrix.stage == 'selenium'
 
-      - id: deps
-        run: |
-          echo "exc=" >> $GITHUB_OUTPUT
-          if [ ${{ matrix.mediawiki-version }} == 'master' ]; then
-            case ${{ matrix.stage }} in
-              "phpunit-unit")
-                echo "exc=GrowthExperiments" >> $GITHUB_OUTPUT
-                ;;
-              "phpunit")
-                echo "exc=CheckUser GrowthExperiments IPInfo" >> $GITHUB_OUTPUT
-                ;;
-              "selenium")
-                # maybe IPInfo?
-                echo "exc=CheckUser GrowthExperiments IPInfo" >> $GITHUB_OUTPUT
-                ;;
-            esac
-          elif [ ${{ matrix.mediawiki-version }} == 'REL1_43' ]; then
-            case ${{ matrix.stage }} in
-              "phpunit-unit")
-              echo "exc=CheckUser GrowthExperiments" >> $GITHUB_OUTPUT
-              ;;
-              "phpunit")
-              echo "exc=GrowthExperiments" >> $GITHUB_OUTPUT
-              ;;
-              "selenium")
-              echo "exc=CheckUser GrowthExperiments IPInfo Popups" >> $GITHUB_OUTPUT
-              ;;
-            esac
-          fi
-
-      - uses: femiwiki/quibble-action@v1
+      - uses: femiwiki/quibble-action@dee0c886057c8c5b7fd0e57400efcf77647404db # main
         id: quibble
         with:
           stage: ${{ matrix.stage }}
@@ -82,7 +52,10 @@ jobs:
           coverage-docker-image: quibble-buster-php74-coverage
           phan-docker-image: mediawiki-phan-php81
           mediawiki-version: ${{ matrix.mediawiki-version }}
-          exclude-dependencies: ${{ steps.deps.outputs.exc }}
+          # v1 expanded the `Echo` dependency transitively via Wikimedia's
+          # dependencies.yaml; main resolves from local sources only, so we pin
+          # that closure explicitly to keep testing the same set of repos.
+          dependencies: AntiSpoof CentralAuth Echo EventLogging MobileFrontend
 
       - name: Upload coverage to Codecov
         if: matrix.stage == 'coverage'


### PR DESCRIPTION
## What

Pin `femiwiki/quibble-action` from `@v1` to its current `main` commit (`dee0c88`), and declare the dependency closure explicitly via the new `dependencies` input.

## Why

quibble-action's `main` [redefined dependency resolution to read from local sources only](https://github.com/femiwiki/quibble-action/commit/dee0c886057c8c5b7fd0e57400efcf77647404db) (the `dependencies` input → manifest `requires` → phan config), dropping the transitive expansion via Wikimedia's `dependencies.yaml` that v1 did on `.github/workflows/dependencies`.

To keep testing the same set of repos under the new mechanism:

- `dependencies: AntiSpoof CentralAuth Echo EventLogging MobileFrontend` — the closure v1 currently expands `Echo` into via `dependencies.yaml`.
- Removed the `deps` step and `exclude-dependencies`. Those excluded `CheckUser GrowthExperiments IPInfo Popups`, which are no longer in the upstream closure, so they were already no-ops.

## Note

Checks already fail on `main`, so failures here are expected. This PR is about preserving *which* test stages and dependency set run, not about turning the suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)