### PR TITLE
ci: remove dead .github/workflows/dependencies file

### DIFF
--- a/.github/workflows/dependencies
+++ b/.github/workflows/dependencies
@@ -1,3 +1,0 @@
-Echo:
-  branch: auto
-  repo: auto


### PR DESCRIPTION
## What

Delete `.github/workflows/dependencies`.

## Why

quibble-action v1 read this file to expand dependencies transitively via Wikimedia's `dependencies.yaml`. Since #929 pinned the action to `main` — which resolves dependencies from local sources only — the file is no longer read by anything. The `Echo` it declared is now covered by the explicit `dependencies: AntiSpoof CentralAuth Echo EventLogging MobileFrontend` input in `extension-test.yml`.

Cleanup that should have ridden along with #929.

🤖 Generated with [Claude Code](https://claude.com/claude-code)