### PR TITLE
ci: test against REL1_43, REL1_44, REL1_45 and master

### DIFF
--- a/.github/workflows/extension-test.yml
+++ b/.github/workflows/extension-test.yml
@@ -11,8 +11,10 @@ jobs:
       fail-fast: false
       matrix:
         mediawiki-version:
-          - master
           - REL1_43
+          - REL1_44
+          - REL1_45
+          - master
         stage:
           - phan
           # - coverage # We really need this coverage for a skin?


### PR DESCRIPTION
## What

Expand the `mediawiki-version` matrix from `master + REL1_43` to **`REL1_43, REL1_44, REL1_45, master`**.

## Why

We want coverage across the currently supported MediaWiki branches, not just the oldest and master.

## Note

This is intentionally **atomic**: it only widens the matrix. CI stays red for now — the per-branch fixes land in follow-up PRs, starting from REL1_43, so each change stays reviewable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)