### PR TITLE
ci: run REL1_45 on a PHP 8.3 image

### DIFF
--- a/.github/workflows/extension-test.yml
+++ b/.github/workflows/extension-test.yml
@@ -27,6 +27,23 @@ jobs:
           - selenium
           # - qunit
           # - api-testing
+        # PHP image per MediaWiki branch: each branch's composer.json sets a
+        # minimum PHP, so the Quibble and phan images must match. REL1_43/44
+        # run on PHP 8.1; REL1_45 needs >= 8.2 (php8.3). master needs >= 8.3 and
+        # is fixed in a follow-up.
+        include:
+          - mediawiki-version: REL1_43
+            quibble-image: quibble-buster-php81
+            phan-image: mediawiki-phan-php81
+          - mediawiki-version: REL1_44
+            quibble-image: quibble-buster-php81
+            phan-image: mediawiki-phan-php81
+          - mediawiki-version: REL1_45
+            quibble-image: quibble-bookworm-php83
+            phan-image: mediawiki-phan-php83
+          - mediawiki-version: master
+            quibble-image: quibble-buster-php81
+            phan-image: mediawiki-phan-php81
 
     runs-on: ubuntu-latest
 
@@ -46,10 +63,10 @@ jobs:
         id: quibble
         with:
           stage: ${{ matrix.stage }}
-          quibble-docker-image: quibble-buster-php81
+          quibble-docker-image: ${{ matrix.quibble-image }}
           # There is no quibble-buster-php81-coverage yet
           coverage-docker-image: quibble-buster-php74-coverage
-          phan-docker-image: mediawiki-phan-php81
+          phan-docker-image: ${{ matrix.phan-image }}
           mediawiki-version: ${{ matrix.mediawiki-version }}
           # v1 expanded the `Echo` dependency transitively via Wikimedia's
           # dependencies.yaml; main resolves from local sources only, so we pin


### PR DESCRIPTION
## What

Map the Quibble/phan Docker images per MediaWiki branch via matrix `include`, and move **REL1_45** to `quibble-bookworm-php83` / `mediawiki-phan-php83`.

## Why

REL1_45's `composer.json` requires `php >= 8.2.0`, but the shared `quibble-buster-php81` image ships PHP 8.1.29, so every REL1_45 job failed at `composer update` for `mediawiki/core`:

```
Root composer.json requires php >=8.2.0 but your php version (8.1.29) does not satisfy that requirement.
```

REL1_43/44 already pass on PHP 8.1 and are left unchanged. `master` needs `php >= 8.3` plus newer packages (oojs-ui, lcobucci/jwt, symfony/mailer); it stays on the old image and **remains red here**, fixed in a follow-up to keep this PR atomic.

## Expected result

REL1_43 ✅ · REL1_44 ✅ · **REL1_45 ✅ (was ❌)** · master ❌ (unchanged, next PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)