### PR TITLE
ci: test against REL1_46

### DIFF
--- a/.github/workflows/extension-test.yml
+++ b/.github/workflows/extension-test.yml
@@ -14,6 +14,7 @@ jobs:
           - REL1_43
           - REL1_44
           - REL1_45
+          - REL1_46
           - master
         stage:
           - phan
@@ -29,8 +30,8 @@ jobs:
           # - api-testing
         # PHP image per MediaWiki branch: each branch's composer.json sets a
         # minimum PHP, so the Quibble and phan images must match. REL1_43/44
-        # run on PHP 8.1; REL1_45 needs >= 8.2 (php8.3). master needs >= 8.3 and
-        # is fixed in a follow-up.
+        # run on PHP 8.1; REL1_45 needs >= 8.2 and REL1_46 needs >= 8.3 (both on
+        # php8.3). master needs >= 8.3 and is fixed in a follow-up.
         include:
           - mediawiki-version: REL1_43
             quibble-image: quibble-buster-php81
@@ -39,6 +40,9 @@ jobs:
             quibble-image: quibble-buster-php81
             phan-image: mediawiki-phan-php81
           - mediawiki-version: REL1_45
+            quibble-image: quibble-bookworm-php83
+            phan-image: mediawiki-phan-php83
+          - mediawiki-version: REL1_46
             quibble-image: quibble-bookworm-php83
             phan-image: mediawiki-phan-php83
           - mediawiki-version: master


### PR DESCRIPTION
## What

Add **REL1_46** to the `mediawiki-version` matrix.

## Details

REL1_46's `composer.json` requires `php >= 8.3.0`, so it runs on `quibble-bookworm-php83` / `mediawiki-phan-php83` (the same images as REL1_45).

## Expected result

REL1_46 should match REL1_45: green except the **notification-flyout `selenium`** test, which fails on 1.45+ until the portlet migration lands (deferred; tracked alongside #925). The per-version fixes continue in follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)