### PR TITLE
fix: support the notification flyout on MediaWiki 1.45 through master

### DIFF
--- a/includes/HookHandler/Portlet.php
+++ b/includes/HookHandler/Portlet.php
@@ -102,6 +102,10 @@ class Portlet implements
 		$insertUrls = [
 			'notifications-all' => [
 				'href' => $url,
+				// Explicit id so the rendered link is always #pt-notifications-all,
+				// which both skins.femiwiki.notifications/init.js and the Selenium
+				// test rely on, regardless of which menu it lands in.
+				'id' => 'pt-notifications-all',
 				'text' => $msgText,
 				'active' => ( $url == $title->getLocalUrl() ),
 				'class' => $linkClasses,
@@ -112,7 +116,12 @@ class Portlet implements
 			]
 		];
 
-		$links['user-menu'] = wfArrayInsertAfter( $links['user-menu'] ?? [], $insertUrls, 'userpage' );
+		// Use the dedicated `notifications` menu slot instead of inserting into
+		// `user-menu` after `userpage`. Since MW 1.45 the user page link is split
+		// out of `user-menu` into its own `user-page` menu, so the old
+		// wfArrayInsertAfter(..., 'userpage') no longer lands where Echo's JS
+		// binds the flyout. getTemplateData() recombines the slots.
+		$links['notifications'] = $insertUrls;
 	}
 
 	/**
@@ -163,13 +172,26 @@ class Portlet implements
 		$this->addMobileOptions( $sktemplate, $links );
 		$this->tweakWatchActions( $sktemplate, $links );
 
+		// On MW 1.45 the user page link lives in both the `user-page` menu and
+		// `user-menu`; on 1.46+ core removes it from `user-menu` for skins that
+		// declare the `user-page` menu. Normalise so data-user-menu-extended
+		// (user-page + notifications + user-menu) never lists it twice.
+		if ( !empty( $links['user-page'] ) ) {
+			unset( $links['user-menu']['userpage'] );
+		}
+
 		foreach ( [
+			'user-page',
 			'user-menu',
 			'actions',
-		] as &$portlet ) {
+		] as $portlet ) {
+			if ( !isset( $links[$portlet] ) ) {
+				continue;
+			}
 			foreach ( $links[$portlet] as $key => &$item ) {
 				$this->addIconToListItem( $item, $key );
 			}
+			unset( $item );
 		}
 	}
 
@@ -203,7 +225,10 @@ class Portlet implements
 			return;
 		}
 
-		$links['namespaces'][$key] = $links['actions'][$key];
+		// Promote into `associated-pages` (rendered by Header.mustache). On 1.46+
+		// the legacy `namespaces` menu is no longer rendered for skins that do
+		// not opt into it, so writing to `namespaces` would drop the link.
+		$links['associated-pages'][$key] = $links['actions'][$key];
 		unset( $links['actions'][$key] );
 	}
 

--- a/includes/SkinFemiwiki.php
+++ b/includes/SkinFemiwiki.php
@@ -51,7 +51,20 @@ class SkinFemiwiki extends SkinMustache {
 		$parentData = parent::getTemplateData();
 		[ $sidebar, $toolbox ] = $this->getSidebar( $parentData['data-portlets-sidebar'] );
 
+		// Render the user page, notifications and user menu as a single menu.
+		// Since MW 1.45 these are separate portlet slots; the `?? ''`/`?? []`
+		// fallbacks keep this working when a slot is absent on a given version.
+		$portlets = $parentData['data-portlets'] ?? [];
+		$userMenu = $portlets['data-user-menu'] ?? [];
+		$extendedUserMenu = [
+			'html-items' =>
+				( $portlets['data-user-page']['html-items'] ?? '' ) .
+				( $portlets['data-notifications']['html-items'] ?? '' ) .
+				( $userMenu['html-items'] ?? '' ),
+		] + $userMenu;
+
 		$commonSkinData = array_merge_recursive( $parentData, [
+			'data-user-menu-extended' => $extendedUserMenu,
 			'data-sidebar' => $sidebar,
 			'html-heading-language-attributes' => $this->prepareHeadingLanguageAttributes(),
 			'html-share-button' => $this->getShare(),

--- a/includes/templates/Header.mustache
+++ b/includes/templates/Header.mustache
@@ -3,7 +3,7 @@
   {{{html-user-message}}}
   <h1 id="firstHeading" class="firstHeading" {{{html-heading-language-attributes}}}>{{{html-title}}}</h1>
   <div id="p-title-buttons">
-    {{#data-portlets.data-namespaces}}{{>Menu}}{{/data-portlets.data-namespaces}}
+    {{#data-portlets.data-associated-pages}}{{>Menu}}{{/data-portlets.data-associated-pages}}
     <div class="right-buttons">
       {{{html-share-button}}}
       {{>Indicator}}

--- a/includes/templates/skin.mustache
+++ b/includes/templates/skin.mustache
@@ -1,9 +1,9 @@
 {{>NavigationBar}}
 <input type="checkbox" id="fw-menu-checkbox" class="mw-checkbox-hack-checkbox">
 <div id="fw-menu" class="fw-portals fw-wiki-portals">
-  {{#data-portlets.data-user-menu}}
+  {{#data-user-menu-extended}}
   {{>Menu}}
-  {{/data-portlets.data-user-menu}}
+  {{/data-user-menu-extended}}
 
   {{#data-sidebar}}
   {{>Menu}}

--- a/resources/skins.femiwiki/interface.less
+++ b/resources/skins.femiwiki/interface.less
@@ -166,7 +166,7 @@
     }
   }
 
-  .mw-portlet-namespaces {
+  .mw-portlet-associated-pages {
     h3 {
       display: none;
     }

--- a/skin.json
+++ b/skin.json
@@ -24,10 +24,6 @@
         "normalize": true,
         "logo": true
       },
-      "targets": [
-        "desktop",
-        "mobile"
-      ],
       "styles": [
         "skins.femiwiki/elements.less",
         "skins.femiwiki/contents.less",
@@ -42,10 +38,6 @@
         "content-body": false,
         "toc": false
       },
-      "targets": [
-        "desktop",
-        "mobile"
-      ],
       "localBasePath": "node_modules/xeicon",
       "remoteSkinPath": "Femiwiki/node_modules/xeicon",
       "styles": {
@@ -57,10 +49,6 @@
     "skins.femiwiki.smallElements": {
       "styles": [
         "skins.femiwiki.smallElements/styles.less"
-      ],
-      "targets": [
-        "desktop",
-        "mobile"
       ]
     },
     "skins.femiwiki.js": {
@@ -68,10 +56,6 @@
         "oojs",
         "oojs-ui-core",
         "mediawiki.page.ready"
-      ],
-      "targets": [
-        "desktop",
-        "mobile"
       ],
       "packageFiles": [
         "skins.femiwiki.js/skin.js",
@@ -82,10 +66,6 @@
       ]
     },
     "skins.femiwiki.notifications": {
-      "targets": [
-        "desktop",
-        "mobile"
-      ],
       "packageFiles": [
         "skins.femiwiki.notifications/init.js"
       ]
@@ -93,20 +73,12 @@
     "skins.femiwiki.dm": {
       "scripts": [
         "mw.fw.js"
-      ],
-      "targets": [
-        "desktop",
-        "mobile"
       ]
     },
     "skins.femiwiki.share": {
       "dependencies": [
         "oojs",
         "oojs-ui-windows"
-      ],
-      "targets": [
-        "desktop",
-        "mobile"
       ],
       "packageFiles": [
         "skins.femiwiki.share/init.js"
@@ -124,10 +96,6 @@
       "messages": [
         "skin-femiwiki-share-dismiss",
         "skin-femiwiki-share-twitter"
-      ],
-      "targets": [
-        "desktop",
-        "mobile"
       ]
     }
   },
@@ -233,6 +201,16 @@
             "skins.femiwiki",
             "skins.femiwiki.xeicon",
             "oojs-ui.styles.icons-interactions"
+          ],
+          "menus": [
+            "user-interface-preferences",
+            "user-page",
+            "user-menu",
+            "notifications",
+            "views",
+            "actions",
+            "variants",
+            "associated-pages"
           ],
           "link": {
             "text-wrapper": {


### PR DESCRIPTION
## What

Make the notification flyout (and the surrounding user menu / title-button portlets) work across **MediaWiki 1.45 → master from a single codebase**, fixing the `flyout for notifications appears` Selenium failure on REL1_45/REL1_46/master.

## Why

Since MW 1.45 the user page link is split out of the `user-menu` slot into its own `user-page` menu, and notifications are expected in a dedicated `notifications` slot. The skin inserted its notification entry into `user-menu` after `userpage`, so on 1.45+ it no longer landed where Echo's JS binds the flyout — `#pt-notifications-all` never opened the OOUI popup.

Verified against core (REL1_45, REL1_46, master): `user-page`, `notifications`, `associated-pages` and the SkinModule `menus` option all exist in every one of these branches, so one codebase can target the whole range.

## Changes

- Notification entry → dedicated `notifications` slot with explicit `id: pt-notifications-all`; recombine `user-page` + `notifications` + `user-menu` into `data-user-menu-extended` (slot reads use `?? ''` fallbacks).
- Unset the duplicate user page link from `user-menu` when a `user-page` menu is present (1.45 has it in both; 1.46+ core already unsets it).
- Promote the watch link into `associated-pages`, render `data-associated-pages` (legacy `namespaces` is not rendered on 1.46+).
- Declare `menus` (matching Vector, without the deprecated `namespaces`/`personal`); drop the long-dead `targets` module property.

Generalises the approach in #925 to keep working across 1.45 → master rather than 1.46-only. `requires` is intentionally left unchanged and the matrix untouched, so CI shows the real result on every branch (1.43 → master).

## Expecting

REL1_45 / REL1_46 / master `selenium` to go green. Watching whether REL1_43/REL1_44 stay green under the same code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)