### PR TITLE
fix: open the notification flyout on MediaWiki 1.45+

### DIFF
--- a/resources/skins.femiwiki.notifications/init.js
+++ b/resources/skins.femiwiki.notifications/init.js
@@ -64,10 +64,12 @@
         // MediaWiki 1.45. The constructor signature is identical; only the way
         // the badge attaches to the DOM differs. Support both so the skin works
         // on MediaWiki 1.43 through master from one codebase.
+        // Cast to a loose type: NotificationBadgeController is not in the
+        // shipped Echo type definitions yet.
+        var echoUi = /** @type {any} */ (mw.echo.ui);
         var BadgeClass =
-          mw.echo.ui.NotificationBadgeController ||
-          mw.echo.ui.NotificationBadgeWidget;
-        var isController = !!mw.echo.ui.NotificationBadgeController;
+          echoUi.NotificationBadgeController || echoUi.NotificationBadgeWidget;
+        var isController = !!echoUi.NotificationBadgeController;
 
         // workaround https://github.com/femiwiki/FemiwikiSkin/issues/212
         BadgeClass.prototype.markAllReadButtonWorkaround = function () {
@@ -80,13 +82,13 @@
           );
         };
 
-        var widgetConfig = {
+        var widgetConfig = /** @type {any} */ ({
           numItems: Number(num),
           convertedNumber: badgeLabel,
           hasUnseen: hasUnseen,
           badgeIcon: 'bell',
           $overlay: mw.echo.ui.$overlay,
-        };
+        });
         if (isController) {
           // 1.45+: the controller enhances the existing badge link in place.
           widgetConfig.$badge = $existingLink;

--- a/resources/skins.femiwiki.notifications/init.js
+++ b/resources/skins.femiwiki.notifications/init.js
@@ -60,29 +60,45 @@
         });
         controller = new mw.echo.Controller(echoApi, modelManager);
 
+        // Echo renamed NotificationBadgeWidget to NotificationBadgeController in
+        // MediaWiki 1.45. The constructor signature is identical; only the way
+        // the badge attaches to the DOM differs. Support both so the skin works
+        // on MediaWiki 1.43 through master from one codebase.
+        var BadgeClass =
+          mw.echo.ui.NotificationBadgeController ||
+          mw.echo.ui.NotificationBadgeWidget;
+        var isController = !!mw.echo.ui.NotificationBadgeController;
+
         // workaround https://github.com/femiwiki/FemiwikiSkin/issues/212
-        mw.echo.ui.NotificationBadgeWidget.prototype.markAllReadButtonWorkaround =
-          function () {
-            echoApi.markAllRead(
-              modelManager
-                .getFiltersModel()
-                .getSourcePagesModel()
-                .getCurrentSource(),
-              ['alert', 'message']
-            );
-          };
-        mw.echo.ui.widget = new mw.echo.ui.NotificationBadgeWidget(
+        BadgeClass.prototype.markAllReadButtonWorkaround = function () {
+          echoApi.markAllRead(
+            modelManager
+              .getFiltersModel()
+              .getSourcePagesModel()
+              .getCurrentSource(),
+            ['alert', 'message']
+          );
+        };
+
+        var widgetConfig = {
+          numItems: Number(num),
+          convertedNumber: badgeLabel,
+          hasUnseen: hasUnseen,
+          badgeIcon: 'bell',
+          $overlay: mw.echo.ui.$overlay,
+        };
+        if (isController) {
+          // 1.45+: the controller enhances the existing badge link in place.
+          widgetConfig.$badge = $existingLink;
+        } else {
+          // 1.43/1.44: the widget builds its own element to replace the link.
+          widgetConfig.href = $existingLink.attr('href');
+        }
+        mw.echo.ui.widget = new BadgeClass(
           controller,
           modelManager,
           links,
-          {
-            numItems: Number(num),
-            convertedNumber: badgeLabel,
-            hasUnseen: hasUnseen,
-            badgeIcon: 'bell',
-            $overlay: mw.echo.ui.$overlay,
-            href: $existingLink.attr('href'),
-          }
+          widgetConfig
         );
 
         modelManager.on('allTalkRead', function () {
@@ -94,8 +110,12 @@
           click: 'markAllReadButtonWorkaround',
         });
 
-        // Replace the link button with the ooui button
-        $existingLink.parent().replaceWith(mw.echo.ui.widget.$element);
+        // 1.43/1.44 only: replace the placeholder link with the widget's
+        // element. On 1.45+ the controller already attached to the existing
+        // $badge, so the link stays in place.
+        if (!isController) {
+          $existingLink.parent().replaceWith(mw.echo.ui.widget.$element);
+        }
 
         // HACK: Now that the module loaded, show the popup
         myWidget = mw.echo.ui.widget;


### PR DESCRIPTION
## What

Fix the notification flyout so it opens on MediaWiki 1.45, 1.46 and master, while keeping 1.43/1.44 working — from a single codebase. One file: `resources/skins.femiwiki.notifications/init.js`.

## Root cause (reproduced in a real browser on 1.45.3)

The skin reimplements Echo's badge popup on top of Echo's internal JS classes. MediaWiki 1.45 renamed `mw.echo.ui.NotificationBadgeWidget` → `mw.echo.ui.NotificationBadgeController` (OOUI widget → controller). The old reference became `undefined`, and `…NotificationBadgeWidget.prototype.…` threw inside the `mw.loader.using('ext.echo.ui.desktop', …)` callback:

```
TypeError: Cannot read properties of undefined (reading 'prototype')
```

The whole callback died, the popup never opened, and the `flyout for notifications appears` Selenium test timed out on 1.45/1.46/master. (`mw.echo` is defined and the module loads fine — the failure is purely this removed class.)

## Fix

The two classes have the **same constructor signature** `(controller, manager, links, config)`; only the DOM attachment differs:
- **Widget (1.43/1.44):** builds its own `$element` → skin does `replaceWith($element)`.
- **Controller (1.45+):** enhances the existing badge link, passed as `config.$badge`.

So pick whichever class the running Echo provides and branch on that one difference. No PHP/portlet changes needed.

## Verification

Reproduced and fixed in a headless browser against a local MediaWiki **1.45.3** + Echo: the single consolidated **"Notifications"** badge is unchanged and its flyout opens as before (screenshot captured locally). CI will confirm `selenium` across REL1_43 → master.

Closes the notification-flyout part of the 1.45→master support effort. (Supersedes #935, which attempted a portlet migration that did not address this JS issue.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)