### PR TITLE
chore: block push when npm test fails (husky pre-push)

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@wdio/spec-reporter": "8.43.0",
         "@wikimedia/types-wikimedia": "^0.3.4",
         "grunt-banana-checker": "^0.10.0",
+        "husky": "^9.1.7",
         "nodejs-file-downloader": "^4.13.0",
         "prettier": "^2",
         "svgo": "^3.0.2",
@@ -3443,6 +3444,22 @@
       "dev": true,
       "engines": {
         "node": ">=16.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "prepare": "husky",
     "test": "npm run lint --silent",
     "lint": "npm run lint:prettier --silent && npm run lint:i18n --silent && npm run lint:type --silent",
     "lint:type": "tsc",
@@ -31,6 +32,7 @@
     "@wdio/spec-reporter": "8.43.0",
     "@wikimedia/types-wikimedia": "^0.3.4",
     "grunt-banana-checker": "^0.10.0",
+    "husky": "^9.1.7",
     "nodejs-file-downloader": "^4.13.0",
     "prettier": "^2",
     "svgo": "^3.0.2",


### PR DESCRIPTION
## Summary

- Installs **husky v9** as a dev dependency.
- Adds a `prepare` script to `package.json` so husky initialises on `npm install`.
- Creates `.husky/pre-push` containing `npm test`, which runs the full lint suite (Prettier, banana-i18n, TypeScript) before every push. A non-zero exit aborts the push.

## How to bypass in an emergency

```
git push --no-verify
```

Use sparingly. The hook exists to keep the remote branch green.

## Test plan

- [x] `npm test` passes locally (Prettier, i18n checker, tsc all green).
- [x] `git push` triggered the pre-push hook automatically and succeeded because the suite passed (visible in the push output above).
- [x] `git config core.hooksPath` returns `.husky/_` after `npm run prepare`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)