### PR TITLE
ci: let quibble-action pick the PHP image per MediaWiki branch

### DIFF
--- a/.github/workflows/extension-test.yml
+++ b/.github/workflows/extension-test.yml
@@ -28,26 +28,6 @@ jobs:
           - selenium
           # - qunit
           # - api-testing
-        # PHP image per MediaWiki branch: each branch's composer.json sets a
-        # minimum PHP, so the Quibble and phan images must match. REL1_43/44
-        # run on PHP 8.1; REL1_45 needs >= 8.2 and REL1_46 needs >= 8.3 (both on
-        # php8.3). master needs >= 8.3 and is fixed in a follow-up.
-        include:
-          - mediawiki-version: REL1_43
-            quibble-image: quibble-buster-php81
-            phan-image: mediawiki-phan-php81
-          - mediawiki-version: REL1_44
-            quibble-image: quibble-buster-php81
-            phan-image: mediawiki-phan-php81
-          - mediawiki-version: REL1_45
-            quibble-image: quibble-bookworm-php83
-            phan-image: mediawiki-phan-php83
-          - mediawiki-version: REL1_46
-            quibble-image: quibble-bookworm-php83
-            phan-image: mediawiki-phan-php83
-          - mediawiki-version: master
-            quibble-image: quibble-buster-php81
-            phan-image: mediawiki-phan-php81
 
     runs-on: ubuntu-latest
 
@@ -63,14 +43,10 @@ jobs:
       - run: npm install
         if: matrix.stage == 'phpunit' || matrix.stage == 'selenium'
 
-      - uses: femiwiki/quibble-action@dee0c886057c8c5b7fd0e57400efcf77647404db # main
+      - uses: femiwiki/quibble-action@f485e3d07409f1524adfb26d12d22830b6b39b06 # main
         id: quibble
         with:
           stage: ${{ matrix.stage }}
-          quibble-docker-image: ${{ matrix.quibble-image }}
-          # There is no quibble-buster-php81-coverage yet
-          coverage-docker-image: quibble-buster-php74-coverage
-          phan-docker-image: ${{ matrix.phan-image }}
           mediawiki-version: ${{ matrix.mediawiki-version }}
           # v1 expanded the `Echo` dependency transitively via Wikimedia's
           # dependencies.yaml; main resolves from local sources only, so we pin


### PR DESCRIPTION
## What

Drop the per-version PHP/image matrix and let quibble-action derive it.

- Remove the `include` mapping (`quibble-image`/`phan-image` per `mediawiki-version`).
- Remove the `quibble-docker-image`, `phan-docker-image` and `coverage-docker-image` `with:` overrides.
- Bump the quibble-action pin to the commit that adds PHP-version derivation (femiwiki/quibble-action#39).

## Why

quibble-action now picks the PHP version (and thus the Quibble/phan images) from `mediawiki-version`, matching each branch's minimum PHP, so the mapping here is redundant maintenance.

This also **unblocks master**: it now runs on the php8.3 image (it requires php ≥ 8.3) instead of the stale php8.1 image, so its setup no longer dies at `composer update`. Combined with the flyout fix (#936), master should now go green like the other branches.

## Expecting

REL1_43 → master all green (1.43/1.44 on php8.1, 1.45 on php8.2, 1.46/master on php8.3 — all bookworm images).

🤖 Generated with [Claude Code](https://claude.com/claude-code)