### PR TITLE
ci: adopt phan 6.x (phan-config 0.20.0)

### DIFF
--- a/.github/workflows/extension-test.yml
+++ b/.github/workflows/extension-test.yml
@@ -56,7 +56,7 @@ jobs:
       - run: npm install
         if: matrix.stage == 'phpunit' || matrix.stage == 'selenium'
 
-      - uses: femiwiki/quibble-action@6bf963a3b99b64861bec07c429edb7bf996d6013 # main
+      - uses: femiwiki/quibble-action@a214585731ad69858468970bce09f046078b37f4 # main
         id: quibble
         with:
           stage: ${{ matrix.stage }}

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "require-dev": {
     "mediawiki/mediawiki-codesniffer": "47.0.0",
-    "mediawiki/mediawiki-phan-config": "0.15.1",
+    "mediawiki/mediawiki-phan-config": "0.20.0",
     "mediawiki/minus-x": "1.1.3",
     "php-parallel-lint/php-console-highlighter": "1.0.0",
     "php-parallel-lint/php-parallel-lint": "1.4.0",

--- a/includes/SkinFemiwiki.php
+++ b/includes/SkinFemiwiki.php
@@ -113,7 +113,7 @@ class SkinFemiwiki extends SkinMustache {
 		if ( !$this->shouldShowShare() ) {
 			return null;
 		}
-		return new ButtonWidget( [
+		return (string)new ButtonWidget( [
 			'id' => 'p-share',
 			'classes' => [ 'fw-button' ],
 			'infusable' => true,


### PR DESCRIPTION
Supersedes #918. Pins quibble-action to the commit that runs phan inside the maintained Quibble image (current php-ast), and bumps `mediawiki-phan-config` to 0.20.0 (phan 6.x).

Draft: the phan stage will now actually run phan 6.x across REL1_43..master for the first time. Any new findings it surfaces will be fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)