### PR TITLE
ci: authenticate the Codecov upload via OIDC

### DIFF
--- a/.github/workflows/extension-test.yml
+++ b/.github/workflows/extension-test.yml
@@ -44,6 +44,12 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    # contents: read to clone; id-token: write so the Codecov upload can
+    # authenticate via OIDC instead of an upload token.
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
       - uses: actions/checkout@v7
 
@@ -70,4 +76,5 @@ jobs:
         if: matrix.stage == 'coverage'
         uses: codecov/codecov-action@v5
         with:
+          use_oidc: true
           directory: ${{ steps.quibble.outputs.coverage }}


### PR DESCRIPTION
The Codecov upload step used neither an upload token nor OIDC (a tokenless upload). Switch it to OIDC, the recommended approach for codecov-action v4+/v5:

- `use_oidc: true` on the codecov step
- `permissions: { contents: read, id-token: write }` on the job, so the runner can mint the OIDC token

Note: the `coverage` stage is currently commented out of the matrix, so this step does not run yet; this wires OIDC for when coverage is re-enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)