### PR TITLE
chore: Bump mediawiki/mediawiki-codesniffer to 49.0.0

### DIFF
--- a/.github/workflows/extension-test.yml
+++ b/.github/workflows/extension-test.yml
@@ -61,6 +61,12 @@ jobs:
         with:
           stage: ${{ matrix.stage }}
           mediawiki-version: ${{ matrix.mediawiki-version }}
+          # composer-test is a version-independent lint of our own source, but
+          # codesniffer >= 49 needs PHP >= 8.2 while REL1_43 (where we run this
+          # stage) otherwise uses 8.1. Pin just this stage to 8.2/bookworm so the
+          # dev tooling installs; the rest keep their derived versions.
+          php-version: ${{ matrix.stage == 'composer-test' && '8.2' || '' }}
+          debian: ${{ matrix.stage == 'composer-test' && 'bookworm' || '' }}
           # v1 expanded the `Echo` dependency transitively via Wikimedia's
           # dependencies.yaml; main resolves from local sources only, so we pin
           # that closure explicitly to keep testing the same set of repos.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "require-dev": {
-    "mediawiki/mediawiki-codesniffer": "47.0.0",
+    "mediawiki/mediawiki-codesniffer": "49.0.0",
     "mediawiki/mediawiki-phan-config": "0.20.0",
     "mediawiki/minus-x": "1.1.3",
     "php-parallel-lint/php-console-highlighter": "1.0.0",


### PR DESCRIPTION
Bumps `mediawiki/mediawiki-codesniffer` 47.0.0 -> 49.0.0.

codesniffer 49 requires PHP >= 8.2, but `composer-test` runs on REL1_43 (PHP 8.1), so a plain bump (#920) fails `composer install` there. `composer-test` is a version-independent lint of our own source, so this pins **just that stage** to PHP 8.2 / bookworm via the action's `php-version`/`debian` inputs. Every other stage keeps its derived version and still runs PHP 8.1 at runtime; `phpcompatibility` still enforces 8.0-8.1 source compatibility.

Verified locally: codesniffer 49.0.0 reports 0 violations on our source.

Supersedes #920.