### PR TITLE
chore: Bump prettier from 2 to 3

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "plugins": ["@prettier/plugin-xml"]
 }

--- a/dev.js
+++ b/dev.js
@@ -55,7 +55,7 @@ await (async () => {
             '  There are some solutions:\n' +
             '  - You can use WSL to run this command: https://learn.microsoft.com/windows/wsl/\n' +
             '  - You can use Docker Desktop to run FrankenPHP: https://docs.docker.com/desktop/setup/install/windows-install/\n' +
-            '  - Or you can try https://github.com/femiwiki/docker-mediawiki\n'
+            '  - Or you can try https://github.com/femiwiki/docker-mediawiki\n',
         );
         process.exit(1);
     }
@@ -104,7 +104,7 @@ await (async () => {
           path.sep +
           `mediawiki-${mediaWikiVersion}` +
           path.sep +
-          'frankenphp'
+          'frankenphp',
       );
     }
     fs.renameSync(`mediawiki-${mediaWikiVersion}`, pathToMediaWiki);
@@ -159,7 +159,7 @@ await (async () => {
     ]) {
       fs.appendFileSync(
         pathToMediaWiki + path.sep + 'LocalSettings.php',
-        appendant + '\n'
+        appendant + '\n',
       );
     }
 
@@ -171,7 +171,7 @@ await (async () => {
   }
 
   console.log(
-    `\n🥳 You can now visit <http://localhost:${caddyPort}> to view your wiki.`
+    `\n🥳 You can now visit <http://localhost:${caddyPort}> to view your wiki.`,
   );
   console.log(`  ID: ${mwUsername}`);
   console.log(`  Password: ${mwPassword}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "xeicon": "https://github.com/xpressengine/XEIcon.git#2.3.3"
       },
       "devDependencies": {
-        "@prettier/plugin-xml": "^2",
+        "@prettier/plugin-xml": "^3.4.2",
         "@types/jquery": "^3.5.16",
         "@types/node-fetch": "^3",
         "@types/unzipper": "^0.10.11",
@@ -23,7 +23,7 @@
         "grunt-banana-checker": "^0.13.0",
         "husky": "^9.1.7",
         "nodejs-file-downloader": "^4.13.0",
-        "prettier": "^2",
+        "prettier": "^3.6.2",
         "svgo": "^3.3.3",
         "typescript": "^5.8.3",
         "unzipper": "^0.12.3",
@@ -1070,13 +1070,16 @@
       }
     },
     "node_modules/@prettier/plugin-xml": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-2.2.0.tgz",
-      "integrity": "sha512-UWRmygBsyj4bVXvDiqSccwT1kmsorcwQwaIy30yVh8T+Gspx4OlC0shX1y+ZuwXZvgnafmpRYKks0bAu9urJew==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@prettier/plugin-xml/-/plugin-xml-3.4.2.tgz",
+      "integrity": "sha512-/UyNlHfkuLXG6Ed85KB0WBF283xn2yavR+UtRibBRUcvEJId2DSLdGXwJ/cDa1X++SWDPzq3+GSFniHjkNy7yg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@xml-tools/parser": "^1.0.11",
-        "prettier": ">=2.4.0"
+        "@xml-tools/parser": "^1.0.11"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0"
       }
     },
     "node_modules/@promptbook/utils": {
@@ -7105,15 +7108,16 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+      "version": "3.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+      "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
       "dev": true,
+      "license": "MIT",
       "bin": {
-        "prettier": "bin-prettier.js"
+        "prettier": "bin/prettier.cjs"
       },
       "engines": {
-        "node": ">=10.13.0"
+        "node": ">=14"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "xeicon": "https://github.com/xpressengine/XEIcon.git#2.3.3"
   },
   "devDependencies": {
-    "@prettier/plugin-xml": "^2",
+    "@prettier/plugin-xml": "^3.4.2",
     "@types/jquery": "^3.5.16",
     "@types/node-fetch": "^3",
     "@types/unzipper": "^0.10.11",
@@ -34,7 +34,7 @@
     "grunt-banana-checker": "^0.13.0",
     "husky": "^9.1.7",
     "nodejs-file-downloader": "^4.13.0",
-    "prettier": "^2",
+    "prettier": "^3.6.2",
     "svgo": "^3.3.3",
     "typescript": "^5.8.3",
     "unzipper": "^0.12.3",

--- a/resources/@types/CheckboxHack.d.ts
+++ b/resources/@types/CheckboxHack.d.ts
@@ -1,36 +1,36 @@
 interface CheckboxHack {
   updateAriaExpanded(checkbox: HTMLInputElement): void;
   bindUpdateAriaExpandedOnInput(
-    checkbox: HTMLInputElement
+    checkbox: HTMLInputElement,
   ): CheckboxHackListeners;
   bindToggleOnClick(
     checkbox: HTMLInputElement,
-    button: HTMLElement
+    button: HTMLElement,
   ): CheckboxHackListeners;
   bindToggleOnEnter(checkbox: HTMLInputElement): CheckboxHackListeners;
   bindDismissOnClickOutside(
     window: Window,
     checkbox: HTMLInputElement,
     button: HTMLElement,
-    target: Node
+    target: Node,
   ): CheckboxHackListeners;
   bindDismissOnFocusLoss(
     window: Window,
     checkbox: HTMLInputElement,
     button: HTMLElement,
-    target: Node
+    target: Node,
   ): CheckboxHackListeners;
   bind(
     window: Window,
     checkbox: HTMLInputElement,
     button: HTMLElement,
-    target: Node
+    target: Node,
   ): CheckboxHackListeners;
   unbind(
     window: Window,
     checkbox: HTMLInputElement,
     button: HTMLElement,
-    listeners: CheckboxHackListeners
+    listeners: CheckboxHackListeners,
   ): void;
 }
 

--- a/resources/skins.femiwiki.js/notificationBadge.js
+++ b/resources/skins.femiwiki.js/notificationBadge.js
@@ -2,8 +2,8 @@ function init() {
   // Notification badge
   var badge = parseInt(
     $('#pt-notifications-all .mw-echo-notifications-badge').attr(
-      'data-counter-num'
-    ) || ''
+      'data-counter-num',
+    ) || '',
   );
   if (!isNaN(badge) && badge !== 0) {
     $('#fw-menu-toggle .badge')

--- a/resources/skins.femiwiki.js/skin.js
+++ b/resources/skins.femiwiki.js/skin.js
@@ -1,6 +1,6 @@
-/** @type {CheckboxHack} */ var checkboxHack = require(/** @type {string} */ (
-  'mediawiki.page.ready'
-)).checkboxHack;
+/** @type {CheckboxHack} */ var checkboxHack = require(
+  /** @type {string} */ ('mediawiki.page.ready'),
+).checkboxHack;
 
 /**
  * Improve the interactivity of the sidebar panel by binding optional checkbox hack enhancements
@@ -30,11 +30,11 @@ function main() {
 
   initCheckboxHack(
     window.document.getElementById('fw-menu-checkbox'),
-    window.document.getElementById('fw-menu-toggle')
+    window.document.getElementById('fw-menu-toggle'),
   );
   initCheckboxHack(
     window.document.getElementById('fw-page-menu-checkbox'),
-    window.document.getElementById('p-menu-toggle')
+    window.document.getElementById('p-menu-toggle'),
   );
 
   var fwMenuToggle = document.querySelector('#fw-menu-toggle');

--- a/resources/skins.femiwiki.moduleSkinStyles/ext.echo.ui.less
+++ b/resources/skins.femiwiki.moduleSkinStyles/ext.echo.ui.less
@@ -4,8 +4,8 @@
 // Attempts to shorten the following two rules may fail due to less.php. Make sure it works when
 // modifying it.
 .mw-echo-ui-toggleReadCircleButtonWidget-circle:not(
-    .mw-echo-ui-toggleReadCircleButtonWidget-circle-unread
-  ) {
+  .mw-echo-ui-toggleReadCircleButtonWidget-circle-unread
+) {
   background-color: @color-secondary2;
 }
 .mw-echo-ui-toggleReadCircleButtonWidget:hover

--- a/resources/skins.femiwiki.moduleSkinStyles/mediawiki.ui.checkbox.less
+++ b/resources/skins.femiwiki.moduleSkinStyles/mediawiki.ui.checkbox.less
@@ -28,7 +28,9 @@
         &:focus + label:before {
           background-color: @color-primary3;
           border-color: @color-primary3;
-          box-shadow: inset 0 0 0 1px @color-primary3, inset 0 0 0 2px white;
+          box-shadow:
+            inset 0 0 0 1px @color-primary3,
+            inset 0 0 0 2px white;
         }
 
         &:hover + label:before {

--- a/resources/skins.femiwiki.moduleSkinStyles/mediawiki.widgets.DateInputWidget.less
+++ b/resources/skins.femiwiki.moduleSkinStyles/mediawiki.widgets.DateInputWidget.less
@@ -23,7 +23,9 @@
 }
 
 .mw-widget-dateInputWidget-calendar:focus {
-  box-shadow: inset 0 0 0 1px @color-primary2, 0 2px 2px 0 rgba(0, 0, 0, 0.25);
+  box-shadow:
+    inset 0 0 0 1px @color-primary2,
+    0 2px 2px 0 rgba(0, 0, 0, 0.25);
 }
 
 .mw-widget-dateInputWidget.oo-ui-widget-enabled

--- a/resources/skins.femiwiki.moduleSkinStyles/mobile.editor.overlay.less
+++ b/resources/skins.femiwiki.moduleSkinStyles/mobile.editor.overlay.less
@@ -30,7 +30,9 @@
     .continue:not(.mw-ui-icon-element),
     .submit:not(.mw-ui-icon-element),
     .progressive:not(.mw-ui-icon-element) {
-      padding: 0 1, 2em;
+      padding:
+        0 1,
+        2em;
     }
   }
 }

--- a/resources/skins.femiwiki.notifications/init.js
+++ b/resources/skins.femiwiki.notifications/init.js
@@ -53,7 +53,7 @@
         unreadCounter = new mw.echo.dm.UnreadNotificationCounter(
           echoApi,
           'all',
-          maxNotificationCount
+          maxNotificationCount,
         );
         modelManager = new mw.echo.dm.ModelManager(unreadCounter, {
           type: 'all',
@@ -78,7 +78,7 @@
               .getFiltersModel()
               .getSourcePagesModel()
               .getCurrentSource(),
-            ['alert', 'message']
+            ['alert', 'message'],
           );
         };
 
@@ -100,7 +100,7 @@
           controller,
           modelManager,
           links,
-          widgetConfig
+          widgetConfig,
         );
 
         modelManager.on('allTalkRead', function () {

--- a/resources/skins.femiwiki.share.ui/mw.fw.ShareDialog.js
+++ b/resources/skins.femiwiki.share.ui/mw.fw.ShareDialog.js
@@ -96,7 +96,7 @@
       mw.config.get('wgSiteName');
 
     this.twitterButton.setHref(
-      'https://twitter.com/intent/tweet?text=' + encodeURIComponent(tweet)
+      'https://twitter.com/intent/tweet?text=' + encodeURIComponent(tweet),
     );
   };
 
@@ -111,7 +111,7 @@
       'POST',
       'https://firebasedynamiclinks.googleapis.com/v1/shortLinks?key=' +
         this.firebaseKey,
-      true
+      true,
     );
 
     xhr.setRequestHeader('Content-Type', 'application/json');
@@ -145,7 +145,7 @@
         suffix: {
           option: 'SHORT',
         },
-      })
+      }),
     );
   };
 

--- a/resources/skins.femiwiki.smallElements/styles.less
+++ b/resources/skins.femiwiki.smallElements/styles.less
@@ -31,8 +31,8 @@ hr#content-end-bar {
   .mw-portlet {
     @three-portlets-min-width: (@portal-min-width * 3) +
       (@portal-column-gap * 2) + (@content-horizontal-padding * 2);
-    @four-portlets-min-width: (@portal-min-width * 4) + (@portal-column-gap * 3) +
-      (@content-horizontal-padding * 2);
+    @four-portlets-min-width: (@portal-min-width * 4) +
+      (@portal-column-gap * 3) + (@content-horizontal-padding * 2);
 
     @min-width: unit(@three-portlets-min-width * @font-size-root-default, px);
     @max-width: unit(@four-portlets-min-width * @font-size-root-default, px);

--- a/resources/skins.femiwiki/contents.less
+++ b/resources/skins.femiwiki/contents.less
@@ -77,7 +77,8 @@
         // Default styles when there's no .mw-content-ltr or .mw-content-rtl, overridden below
 
         /* @embed */
-        background-image: linear-gradient(transparent, transparent),
+        background-image:
+          linear-gradient(transparent, transparent),
           url(../../../../resources/src/mediawiki.skinning/images/magnify-clip-ltr.svg);
         // Don't annoy people who copy-paste everything too much
         -moz-user-select: none;
@@ -249,7 +250,8 @@ body.mw-hide-empty-elt .mw-empty-elt {
 
     div.magnify a {
       /* @embed */
-      background-image: linear-gradient(transparent, transparent),
+      background-image:
+        linear-gradient(transparent, transparent),
         url(../../../../resources/src/mediawiki.skinning/images/magnify-clip-ltr.svg);
     }
   }
@@ -267,7 +269,8 @@ body.mw-hide-empty-elt .mw-empty-elt {
 
     div.magnify a {
       /* @embed */
-      background-image: linear-gradient(transparent, transparent),
+      background-image:
+        linear-gradient(transparent, transparent),
         url(../../../../resources/src/mediawiki.skinning/images/magnify-clip-rtl.svg);
     }
   }

--- a/resources/skins.femiwiki/interface-gnb.less
+++ b/resources/skins.femiwiki/interface-gnb.less
@@ -204,8 +204,8 @@
   .mw-portlet {
     @three-portlets-min-width: (@portal-min-width * 3) +
       (@portal-column-gap * 2) + (@content-horizontal-padding * 2);
-    @four-portlets-min-width: (@portal-min-width * 4) + (@portal-column-gap * 3) +
-      (@content-horizontal-padding * 2);
+    @four-portlets-min-width: (@portal-min-width * 4) +
+      (@portal-column-gap * 3) + (@content-horizontal-padding * 2);
 
     // Convert from rem to px
     @min-width: unit(@three-portlets-min-width * @font-size-root-default, px);

--- a/resources/variables.less
+++ b/resources/variables.less
@@ -22,8 +22,15 @@
 
 // https://github.com/femiwiki/FemiwikiSkin/issues/228
 // https://github.com/femiwiki/remote-gadgets/pull/26
-@font-family-ja: 'Segoe UI', Meiryo, system-ui, -apple-system,
-  BlinkMacSystemFont, 'Noto Sans CJK KR', '본고딕', sans-serif;
+@font-family-ja:
+  'Segoe UI',
+  Meiryo,
+  system-ui,
+  -apple-system,
+  BlinkMacSystemFont,
+  'Noto Sans CJK KR',
+  '본고딕',
+  sans-serif;
 
 @font-family-ko: 'Apple SD Gothic Neo', 'Noto Sans KR', '본고딕',
   'Noto Sans CJK KR', 'KoPubDotum Medium', '나눔바른고딕', '나눔고딕',
@@ -226,7 +233,8 @@
   max-width: 100%;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
-  background: -webkit-radial-gradient(
+  background:
+    -webkit-radial-gradient(
         left ellipse,
         rgba(0, 0, 0, 0.2) 0%,
         rgba(0, 0, 0, 0) 75%
@@ -236,8 +244,10 @@
         right ellipse,
         rgba(0, 0, 0, 0.2) 0%,
         rgba(0, 0, 0, 0) 75%
-      ) 100% center;
-  background: radial-gradient(
+      )
+      100% center;
+  background:
+    radial-gradient(
         ellipse at left,
         rgba(0, 0, 0, 0.2) 0%,
         rgba(0, 0, 0, 0) 75%
@@ -249,7 +259,9 @@
         rgba(0, 0, 0, 0) 75%
       )
       100% center;
-  background-size: 10px 100%, 10px 100%;
+  background-size:
+    10px 100%,
+    10px 100%;
   background-attachment: scroll, scroll;
   background-repeat: no-repeat;
 


### PR DESCRIPTION
Bumps `prettier` 2.8.8 -> 3.6.2.

prettier 3 has two breaking changes that a plain bump (#892) trips over:

1. **Plugins are no longer auto-loaded.** `@prettier/plugin-xml` is bumped to `^3` and declared in `.prettierrc` so `.phpcs.xml` is still formatted.
2. **`trailingComma` defaults to `all`.** The affected JS/TS/LESS sources are reformatted accordingly.

All changes are pure formatting, no behavior change. Verified locally: `prettier . --check` and `tsc` both pass.

Supersedes #892.