### PR TITLE
chore: exclude local mediawiki checkout from tsc

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,10 @@
     // OOUI does not have type definitions.
     "resources/ooui",
     "resources/skins.femiwiki.share*",
-    "tests"
+    "tests",
+    // Local MediaWiki checkout created by `npm run dev`; scanning it makes
+    // checkJs balloon until tsc runs out of memory.
+    "mediawiki"
   ],
   "compilerOptions": {
     "resolveJsonModule": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,8 +6,7 @@
     "resources/ooui",
     "resources/skins.femiwiki.share*",
     "tests",
-    // Local MediaWiki checkout created by `npm run dev`; scanning it makes
-    // checkJs balloon until tsc runs out of memory.
+    // Local `npm run dev` checkout; scanning OOMs tsc.
     "mediawiki"
   ],
   "compilerOptions": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "resources/ooui",
     "resources/skins.femiwiki.share*",
     "tests",
-    // Local `npm run dev` checkout; scanning OOMs tsc.
+    // Local `npm run dev` checkout; not our code.
     "mediawiki"
   ],
   "compilerOptions": {


### PR DESCRIPTION
`npm run dev` checks out a full MediaWiki into `mediawiki/`. tsconfig did not exclude it, so `tsc` (`allowJs` + `checkJs`) needlessly type-checks the entire vendored checkout, making every `tsc` run (and the husky pre-push `npm test`) slow and memory-heavy (~3.7 GB). It is not our code to type-check.

Adding `mediawiki` to `exclude` skips it. CI is unaffected (no `mediawiki/` there).