### PR TITLE
chore: use official release-please simple type instead of fork

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,11 +19,11 @@ jobs:
           application_id: ${{ vars.PAT_APPLICATION_ID }}
           application_private_key: ${{ secrets.PAT_APPLICATION_PRIVATE_KEY }}
 
-      - uses: femiwiki/release-please-action@femiwiki
+      - uses: googleapis/release-please-action@v4
         id: release-please-action
         with:
           token: ${{ steps.get_workflow_token.outputs.token }}
-          release-type: mediawiki-skin
+          release-type: simple
     outputs:
       tag_name: ${{ steps.release-please-action.outputs.tag_name }}
       upload_url: ${{ steps.release-please-action.outputs.upload_url }}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,14 @@
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
       "draft": false,
-      "prerelease": false
+      "prerelease": false,
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "skin.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
We forked release-please (`femiwiki/release-please-action@femiwiki`) only to add a custom `mediawiki-skin` release type. Its entire job was to bump `skin.json`'s `version` field on each release, plus update `CHANGELOG.md` (which every strategy does anyway).

The official `simple` type plus an `extra-files` JSON updater does exactly the same thing, so we can drop the fork.

## Changes
- workflow: `femiwiki/release-please-action@femiwiki` → `googleapis/release-please-action@v4`
- `release-type`: `mediawiki-skin` → `simple`
- `release-please-config.json`: add an `extra-files` entry updating `skin.json` `$.version`

## Equivalence
The custom `mediawiki-skin` strategy pushed exactly two updates: `CHANGELOG.md` (standard sections) and `skin.json` `$.version` (via a formatting-preserving JSON updater). The official `simple` strategy gives the CHANGELOG; `extra-files` with `{"type":"json","path":"skin.json","jsonpath":"$.version"}` gives the `skin.json` bump using the same `jsonStringify` serializer, so formatting is preserved. Manifest/tag/release come from the shared machinery either way.

`simple` also registers `version.txt` with `createIfMissing: false`; we have no `version.txt`, so it is a silent no-op (nothing to suppress).

Net file changes per release are identical to the fork.